### PR TITLE
New simulated_template() method and new file injection.py, new error messages for fit.run() when delta_t mismatches occur, and new method argument defaults for fit.run() and compute_acfs()

### DIFF
--- a/docs/source/ringdown.rst
+++ b/docs/source/ringdown.rst
@@ -44,6 +44,14 @@ ringdown.qnms module
    :undoc-members:
    :show-inheritance:
 
+ringdown.injection module
+--------------------
+
+.. automodule:: ringdown.injection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/examples/GW150914_circular.ipynb
+++ b/examples/GW150914_circular.ipynb
@@ -23,7 +23,8 @@
    "id": "a24f6670",
    "metadata": {},
    "source": [
-    "This first cell must be executed first in order for Stan's multiprocessing code to not crash some MacOS setups; on linux it's not needed."
+    "\n",
+    "This first cell must be executed first in order for Stan's multiprocessing code to not crash some MacOS setups; on linux it's not needed.\n"
    ]
   },
   {
@@ -60,10 +61,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "ba4d994a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'arviz'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/yy/jvznk621161g2th8wg8tdfm40000gp/T/ipykernel_7938/3359537731.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0marviz\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0maz\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mh5py\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpandas\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mseaborn\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0msns\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'arviz'"
+     ]
+    }
+   ],
    "source": [
     "import arviz as az\n",
     "import h5py\n",
@@ -1263,7 +1276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/ringdown/__init__.py
+++ b/ringdown/__init__.py
@@ -4,11 +4,13 @@ from .data import *
 from .fit import *
 from .kde_contour import *
 from .peak import *
+from .injection import *
 from pylab import *
 from . import qnms
 from . import data
 from . import fit
 from . import peak
+from . import injection
 
 # ############################################################################
 # rcParams

--- a/ringdown/data.py
+++ b/ringdown/data.py
@@ -301,7 +301,7 @@ class AutoCovariance(TimeSeries):
 
     @classmethod
     def from_data(self, d, n=None, dt=1, nperseg=None, f_low=None,
-                  method='td'):
+                  method='fd'):
         dt = getattr(d, 'delta_t', dt)
         n = n or len(d)
         if method.lower() == 'td':
@@ -361,4 +361,3 @@ class AutoCovariance(TimeSeries):
         elif isinstance(data, TimeSeries):
             w_data = TimeSeries(w_data, index=data.index)
         return w_data
-

--- a/ringdown/data.py
+++ b/ringdown/data.py
@@ -309,7 +309,7 @@ class AutoCovariance(TimeSeries):
             rho = ifftshift(rho)
             rho = rho[:n] / len(d)
         elif method.lower() == 'fd':
-            nperseg = nperseg or 3*len(d)
+            nperseg = nperseg or 1/dt
             freq, psd = sig.welch(d, fs=1/dt, nperseg=nperseg)
             rho = 0.5*np.fft.irfft(psd)[:n] / dt
         else:

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -302,7 +302,7 @@ class Fit(object):
         n_jobs = kws.pop('n_jobs', chains)
         n_iter = kws.pop('iter', 2000*n)
         metric = kws.pop('metric', 'dense_e')
-        adapt_delta = kws.pop('adapt_delta', 0.95)
+        adapt_delta = kws.pop('adapt_delta', 0.8)
         stan_kws = {
             'iter': n_iter,
             'thin': n,

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -290,6 +290,9 @@ class Fit(object):
 
         additional kwargs are passed to pystan.model.sampling
         """
+        for ifo in self.ifos: #check if delta_t of ACFs is equal to delta_t of data
+            if self.acfs[ifo].delta_t != self.data[ifo].delta_t:
+                raise ValueError("delta_t of ACFs does not match delta_t of data for all IFOs")
         # get model input
         stan_data = self.model_input
         stan_data['only_prior'] = int(prior)
@@ -299,13 +302,14 @@ class Fit(object):
         n_jobs = kws.pop('n_jobs', chains)
         n_iter = kws.pop('iter', 2000*n)
         metric = kws.pop('metric', 'dense_e')
+        adapt_delta = kws.pop('adapt_delta', 0.95)
         stan_kws = {
             'iter': n_iter,
             'thin': n,
             'init': (kws.pop('init_dict', {}),)*chains,
             'n_jobs': n_jobs,
             'chains': chains,
-            'control': {'metric': metric}
+            'control': {'metric': metric, 'adapt_delta': adapt_delta}
         }
         stan_kws.update(kws)
         # run model and store
@@ -528,3 +532,4 @@ class Fit(object):
 
     def whiten(self, datas):
         return {i: Data(self.acfs[i].whiten(d), ifo=i) for i,d in datas.items()}
+

--- a/ringdown/injection.py
+++ b/ringdown/injection.py
@@ -3,29 +3,50 @@ import lal
 from .data import *
 
 def simulated_template(freq,tau,smprate,duration,theta,phi,amplitude,alpha,declination,ifolist,tgps,ellip,psi=0):
-    #Function to make a simulated signal, as in "Analyzing black-hole ringdowns" Eqns. 9-13, here using a 
-    #"ring-up" followed by a ring-down as modeled by a time decay of exp(-abs(t-tgps-time_delay_dict[ifo])*v)
-    #
-    #The various paramters are defined as follows
-    #freq: frequency of each tone, Hz
-    #tau: damping time of each tone, seconds
-    #phase: phasor offset for complex amplitude, note 2 independent phases phi_l,+m,n and phi_l,-m,n are expected,
-    #       thus for each tone the list must be entered as [[phi0plus,phi0minus],[phi1plus,ph1minus],....], in radians
-    #ellip: ellipticity of each tone, -1<=ellip<=1
-    #smprate: sample rate of signal, Hz
-    #duration: length of time of the full signal, seconds
-    #alpha: source right ascension
-    #declination: source declination
-    #psi: degenerate with alpha and declination, therefore evaluated at arbitrary fixed value of zero
-    #ifolist: List of ifos as strings, i.e. ["H1","L1"]
-    #tgps: gps time for peak of signal
-    #amplitude: amplitude of each tone
-    #
-    #Note freq,tau,phase,amplitude,epsilon must all be entered as a list ordered by overtones,
-    #and in general this function works best for durations much longer than the time delay
-    #
-    #No noise is overlaid on this template - noise should be generated separately as another ringdown.TimeSeries object
-    #and overlaid on this template
+     """Function to make a simulated signal, as in "Analyzing black-hole ringdowns" Eqns. 11-13, here using a 
+        "ring-up" followed by a ring-down as modeled by a time decay of exp(-abs(t-tgps-time_delay_dict[ifo])*v).
+                
+        Note that in general this function works best for durations much longer than the time delay. No noise is overlaid on this template - noise should 
+        be generated separately as another ringdown.TimeSeries object and overlaid on this template.
+        
+        Arguments
+        ---------
+        freq: list
+            list of frequencies of each tone, Hz
+        tau: list
+            damping time of each tone, seconds
+        theta: list
+            angle of ellipse in h+,hx space, in radians
+        phi: list
+            phase offset of sinusoids, in radians
+        ellip: list
+            ellipticity of each tone, -1<=ellip<=1
+        smprate: float
+            sample rate of signal, Hz
+        duration: float
+            length of time of the full signal, seconds
+        alpha: float
+            source right ascension
+        declination: float
+            source declination
+        psi: float
+            degenerate with alpha and declination, therefore evaluated at arbitrary fixed value of zero
+        ifolist: list
+            List of ifos as strings, i.e. ["H1","L1"]
+        tgps: float
+            gps time for peak of signal
+        amplitude: list
+            amplitude of each tone
+            
+        Returns
+        -------
+        sig_dict : dict
+            Dict of signal TimeSeries for each ifo.
+        modes_dict: dict
+            Dict of mode TimeSeries for each ifo.
+        time_delay_dict: dict
+            Dict of TimeDelayFromEarthCenter for each ifo.
+        """
     N = int((duration*smprate))
     t = arange(N)/smprate+tgps-duration/2.0 #list of times that will be used as fake data input
     s = TimeSeries(zeros_like(t), index=t) #array for template signal

--- a/ringdown/injection.py
+++ b/ringdown/injection.py
@@ -1,0 +1,63 @@
+from pylab import *
+import lal
+from .data import *
+
+def simulated_template(freq,tau,smprate,duration,phase,amplitude,alpha,declination,ifolist,tgps,ellip,psi=0):
+    #Function to make a simulated signal, as in "Analyzing black-hole ringdowns" Eqns. 9-13, here using a 
+    #"ring-up" followed by a ring-down as modeled by a time decay of exp(-abs(t-tgps-time_delay_dict[ifo])*v)
+    #
+    #The various paramters are defined as follows
+    #freq: frequency of each tone, Hz
+    #tau: damping time of each tone, seconds
+    #phase: phasor offset for complex amplitude, note 2 independent phases phi_l,+m,n and phi_l,-m,n are expected,
+    #       thus for each tone the list must be entered as [[phi0plus,phi0minus],[phi1plus,ph1minus],....], in radians
+    #ellip: ellipticity of each tone, -1<=ellip<=1
+    #smprate: sample rate of signal, Hz
+    #duration: length of time of the full signal, seconds
+    #alpha: source right ascension
+    #declination: source declination
+    #psi: degenerate with alpha and declination, therefore evaluated at arbitrary fixed value of zero
+    #ifolist: List of ifos as strings, i.e. ["H1","L1"]
+    #tgps: gps time for peak of signal
+    #amplitude: amplitude of each tone
+    #
+    #Note freq,tau,phase,amplitude,epsilon must all be entered as a list ordered by overtones,
+    #and in general this function works best for durations much longer than the time delay
+    #
+    #No noise is overlaid on this template - noise should be generated separately as another ringdown.TimeSeries object
+    #and overlaid on this template
+    N = int((duration*smprate))
+    t = arange(N)/smprate+tgps-duration/2.0 #list of times that will be used as fake data input
+    s = TimeSeries(zeros_like(t), index=t) #array for template signal
+    hplus = TimeSeries(zeros_like(t), index=t) #array for h_plus polarization, h_plus = hcos*cos(theta) - epsilon*hsin*sin(theta)
+    hcross = TimeSeries(zeros_like(t), index=t) #array for h_cross polarization, h_cross = hcos*sin(theta) + epsilon*hsin*cos(theta)
+    hsin = TimeSeries(zeros_like(t), index=t) #sine quadrature
+    hsin = TimeSeries(zeros_like(t), index=t) #cosine quadrature
+    sig_dict = {} #dicts used for template output
+    lal_det = {} #ifo information
+    modes_dict = {} #individual mode information
+    antenna_patterns = {} #antenna patterns projected onto modes
+    time_delay_dict = {} #time delays from Earth center
+    omega = 2*pi*array(freq) #frequencies
+    gamma = 1./array(tau) #damping
+    gmst = lal.GreenwichMeanSiderealTime(tgps)
+    theta = 0.0 #tilt angle in phase space wrt h_plus
+    phi = 0.0 #phasor offset
+    for ifo in ifolist:
+        s = s-s #hacky way to zero out the arrays for fresh signal in each ifo
+        lal_det[ifo] = lal.cached_detector_by_prefix[ifo]
+        antenna_patterns[ifo] = lal.ComputeDetAMResponse(lal_det[ifo].response, alpha, declination, psi, gmst)
+        time_delay_dict[ifo] = lal.TimeDelayFromEarthCenter(lal_det[ifo].location, alpha, declination, tgps)
+        modes_dict[ifo]=[]
+        for (w,v,p,A,E,n) in zip(omega,gamma,phase,amplitude,ellip,arange(len(omega))):
+            theta = -(p[0]+p[1])/2.0
+            phi = (p[0]-p[1])/2.0
+            hsin = TimeSeries(A*exp(-abs(t-tgps-time_delay_dict[ifo])*v)*sin(w*(t-tgps-time_delay_dict[ifo])-phi), index=t)
+            hcos = TimeSeries(A*exp(-abs(t-tgps-time_delay_dict[ifo])*v)*cos(w*(t-tgps-time_delay_dict[ifo])-phi), index=t)
+            hplus= hcos*cos(theta)-E*hsin*sin(theta)
+            hcross= hcos*sin(theta)+E*hsin*cos(theta)
+            m = antenna_patterns[ifo][0]*hplus+antenna_patterns[ifo][1]*hcross
+            s += m
+            modes_dict[ifo].append(m)
+        sig_dict[ifo]=s    
+    return sig_dict, modes_dict, time_delay_dict

--- a/ringdown/stan/ringdown_mchi.stan
+++ b/ringdown/stan/ringdown_mchi.stan
@@ -114,7 +114,7 @@ transformed parameters {
   }
 
   if ((flat_A_ellip) && (only_prior)) {
-      for (i in 1:nmode-1) {
+      for (i in 1:nmode) {
           if (A[i] > A_scale) reject("A", i, " > A_scale");
       }
   }

--- a/ringdown/stan/ringdown_mchi.stan
+++ b/ringdown/stan/ringdown_mchi.stan
@@ -115,24 +115,26 @@ transformed parameters {
 
   if ((flat_A_ellip) && (only_prior)) {
       for (i in 1:nmode) {
-          if (A[i] > A_scale) reject("A", i, " > A_scale");
+          if (A[i] > 2*A_scale) reject("A", i-1, " > 2*A_scale");
       }
   }
 
-  for (i in 1:nobs) {
-    real torigin;
-    h_det[i] = rep_vector(0.0, nsamp);
+  if ( only_prior == 0 ) {
+    for (i in 1:nobs) {
+      real torigin;
+      h_det[i] = rep_vector(0.0, nsamp);
 
-    if (i > 1) {
-      torigin = t0[i] + dts[i-1];
-    } else {
-      torigin = t0[i];
-    }
+      if (i > 1) {
+        torigin = t0[i] + dts[i-1];
+      } else {
+        torigin = t0[i];
+      }
 
     for (j in 1:nmode) {
       h_det_mode[i, j] = rd(times[i] - torigin, f[j], gamma[j], Apx[j], Apy[j], Acx[j], Acy[j], FpFc[i][1], FpFc[i][2]);
       h_det[i] = h_det[i] + h_det_mode[i,j];
     }
+  }
   }
 }
 

--- a/ringdown/stan/ringdown_mchi_aligned.stan
+++ b/ringdown/stan/ringdown_mchi_aligned.stan
@@ -108,7 +108,7 @@ transformed parameters {
   }
 
   if ((flat_A) && (only_prior)) {
-      for (i in 1:nmode-1) {
+      for (i in 1:nmode) {
           if (A[i] > A_scale) reject("A", i, " > A_scale");
       }
   }


### PR DESCRIPTION
1) Raise ValueError if the ACF delta_t is different from the data delta_t when fit.run() is called
2) Default compute_acfs() to fd instead of td argument, since it appears that there are some possible numerical instabilities in calculating the ACF directly in the time domain
3) fit.run() now takes adapt_delta as an argument, with the default being set to 0.8 as per PyStan docs
4) A new file called "injection.py" is now included in ringdown. This file currently contains a method called "simulated_template()", which generates a template as per equations 11-13 of (https://arxiv.org/pdf/2107.05609.pdf). The method takes in any arbitrary set of parameters for sample rate, GPS time of peak strain, signal duration (the midpoint of the duration is located at the peak time at the Earth's center), mode frequencies, damping times, phases, amplitudes, ellipticities, sky location, and different interferometers: it then returns a fake signal consisting of a "ring-up" and a ringdown by using an exponential decay of the form exp(-abs(t-tgps-time_delay_dict[ifo])*v), where v is the damping rate. In addition to returning the full strain, the method will also return the individual modes and the time delays from the Earth's center for each interferometer. This type of fake signal is useful for diagnostic tests of the ringdown framework, and the intention is to expand the contents of injection.py to include more sophisticated methods for generating noise and/or numerical relativity injections. Note that simulated_template() does not consider the noise of the detector.

As an example to demonstrate simulated_template(), the plots below show the results of running with the following parameters:
s = 8192 #sample at 8192 Hz
d = 2 #signal lasts 2 seconds
f = [250,245] #frequency
T = [0.004,0.0014] #damping time
th = [2.00,1.00] #theta angle of ellipse in h+,hx space
ph = [-2.0,1.0] #phi phase offset of sinusoids
amp = [15,20]#amplitude of each mode
E = [0.25,0.25]#ellipticity
ifos = ["H1","L1"]
tpeak=32.0
signal, modes, time_delays = ringdown.simulated_template(freq=f,tau=T,smprate=s,duration=d,theta=th,phi=ph,amplitude=amp,alpha=1.95,
                                          declination=-1.27,ifolist=ifos,ellip=E,tgps=tpeak)

<img width="396" alt="image" src="https://user-images.githubusercontent.com/68401264/154567050-98fe141f-9804-46a2-89bb-cec24c725163.png">
