### PR TITLE
Sped up sampling by a factor of two!

### DIFF
--- a/ringdown/data.py
+++ b/ringdown/data.py
@@ -648,17 +648,13 @@ class AutoCovariance(TimeSeries):
         ow_x = sl.solve_toeplitz(self.iloc[:len(x)], x)
         return dot(ow_x, y)/sqrt(dot(x, ow_x))
 
-    def whiten(self, data, drift=1):
+    def whiten(self, data):
         """Whiten stretch of data using ACF.
 
         Arguments
         ---------
         data : array, TimeSeries
             unwhitened data.
-
-        drift : float, default=1
-            factor to apply to noise amplitude before whitening (accounts for
-            short-term noise drift)
 
         Returns
         -------
@@ -669,7 +665,7 @@ class AutoCovariance(TimeSeries):
             assert (data.delta_t == self.delta_t)
         # whiten stretch of data using Cholesky factor
         L = self.iloc[:len(data)].cholesky
-        w_data = np.linalg.solve(drift*L, data)
+        w_data = np.linalg.solve(L, data)
         # return same type as input
         if isinstance(data, Data):
             w_data = Data(w_data, index=data.index, ifo=data.ifo)

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -200,8 +200,7 @@ class Fit(object):
 
     @property
     def _default_prior(self):
-        # turn off ACF drift correction by default.
-        default = {'A_scale': None, 'drift_scale': 0.0}
+        default = {'A_scale': None}
         if self.model == 'ftau':
             # TODO: set default priors based on sampling rate and duration
             default.update(dict(
@@ -983,7 +982,7 @@ class Fit(object):
         else:
             return self._n_analyze
 
-    def whiten(self, datas, drifts=None) -> dict:
+    def whiten(self, datas) -> dict:
         """Return whiten data for all detectors.
 
         See also :meth:`ringdown.data.AutoCovariance.whiten`.
@@ -992,8 +991,6 @@ class Fit(object):
         ---------
         datas : dict
             dictionary of data to be whitened for each detector.
-        drifts : dict
-            optional ACF scale drift factors for each detector.
 
         Returns
         -------
@@ -1001,9 +998,7 @@ class Fit(object):
             dictionary of :class:`ringdown.data.Data` with whitned data for
             each detector.
         """
-        if drifts is None:
-            drifts = {i : 1 for i in datas.keys()}
-        return {i: Data(self.acfs[i].whiten(d, drift=drifts[i]), ifo=i) 
+        return {i: Data(self.acfs[i].whiten(d), ifo=i) 
                 for i,d in datas.items()}
 
     def draw_sample(self, map=False, prior=False, rng=None, seed=None):

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -304,10 +304,7 @@ class Fit(object):
             times=[d.time for d in data_dict.values()],
             strain=list(data_dict.values()),
             L=[a.iloc[:self.n_analyze].cholesky for a in self.acfs.values()],
-            FpFc = list(self.antenna_patterns.values()),
-            # default priors
-            dt_min=-1E-6,
-            dt_max=1E-6
+            FpFc = list(self.antenna_patterns.values())
         )
 
         if 'mchi' in self.model:

--- a/ringdown/stan/ringdown_ftau.stan
+++ b/ringdown/stan/ringdown_ftau.stan
@@ -22,8 +22,6 @@ data {
   
   real A_scale;
 
-  real drift_scale;
-
   int only_prior;
 }
 
@@ -39,7 +37,6 @@ transformed data {
 }
 
 parameters {
-  real log_drift_unit[nobs];
   vector<lower=f_min, upper=f_max>[nmode] f;
   real gamma_raw[nmode];
 
@@ -48,7 +45,6 @@ parameters {
 }
 
 transformed parameters {
-  real drift[nobs];
   vector[nmode] gamma;
   real gamma_logjac;
   vector[nsamp] h_det_mode[nobs,nmode];
@@ -57,7 +53,6 @@ transformed parameters {
 
   for (i in 1:nobs) {
     A[i] = sqrt(Ax[i]*Ax[i] + Ay[i]*Ay[i]);
-    drift[i] = exp(log_drift_unit[i]*drift_scale);
   }
 
   {
@@ -87,9 +82,6 @@ transformed parameters {
 }
 
 model {
-  /* drift[i] ~ lognormal(0, drift_scale) */
-  log_drift_unit ~ std_normal();
-
   /* We want a flat prior on A, phi; thus need Jacobian to d(A, phi) / d(Ax, Ay) = 1/r */
   for (i in 1:nmode) {
     target += -log(A[i]);
@@ -104,7 +96,7 @@ model {
 
   if ( only_prior == 0 ) {
       for (i in 1:nobs) {
-        strain[i] ~ multi_normal_cholesky(h_det[i], drift[i]*L[i]);
+        strain[i] ~ multi_normal_cholesky(h_det[i], L[i]);
       }
   }
 }

--- a/ringdown/stan/ringdown_mchi.stan
+++ b/ringdown/stan/ringdown_mchi.stan
@@ -49,9 +49,6 @@ data {
 
   real A_scale;
 
-  real dt_min;
-  real dt_max;
-
   real df_max;
   real dtau_max;
 
@@ -76,8 +73,6 @@ parameters {
   vector[nmode] Apy_unit;
   vector[nmode] Acx_unit;
   vector[nmode] Acy_unit;
-
-  vector<lower=dt_min, upper=dt_max>[nobs-1] dts;
 
   vector<lower=-df_max,upper=df_max>[nmode] df;
   vector<lower=-dtau_max,upper=dtau_max>[nmode] dtau;
@@ -129,14 +124,8 @@ transformed parameters {
       real torigin;
       h_det[i] = rep_vector(0.0, nsamp);
 
-      if (i > 1) {
-        torigin = t0[i] + dts[i-1];
-      } else {
-        torigin = t0[i];
-      }
-
     for (j in 1:nmode) {
-      h_det_mode[i, j] = rd(times[i] - torigin, f[j], gamma[j], Apx[j], Apy[j], Acx[j], Acy[j], FpFc[i][1], FpFc[i][2]);
+      h_det_mode[i, j] = rd(times[i] - t0[i], f[j], gamma[j], Apx[j], Apy[j], Acx[j], Acy[j], FpFc[i][1], FpFc[i][2]);
       h_det[i] = h_det[i] + h_det_mode[i,j];
     }
   }

--- a/ringdown/stan/ringdown_mchi.stan
+++ b/ringdown/stan/ringdown_mchi.stan
@@ -49,8 +49,6 @@ data {
 
   real A_scale;
 
-  real drift_scale;
-
   real dt_min;
   real dt_max;
 
@@ -71,7 +69,6 @@ transformed data {
 }
 
 parameters {
-  real log_drift_unit[nobs];
   real<lower=M_min, upper=M_max> M;
   real<lower=chi_min, upper=chi_max> chi;
 
@@ -87,7 +84,6 @@ parameters {
 }
 
 transformed parameters {
-  real drift[nobs];
   vector[nmode] gamma;
   vector[nmode] f;
   vector[nsamp] h_det_mode[nobs,nmode];
@@ -100,10 +96,6 @@ transformed parameters {
 
   vector[nmode] A;
   vector[nmode] ellip;
-
-  for (i in 1:nobs) {
-    drift[i] = exp(log_drift_unit[i]*drift_scale);
-  }
 
   for (i in 1:nmode) {
     Apx[i] = A_scale*Apx_unit[i];
@@ -152,9 +144,6 @@ transformed parameters {
 }
 
 model {
-  /* drift ~ lognormal(0, drift_scale) */
-  log_drift_unit ~ std_normal();
-
   /* Amplitude prior */
   if (flat_A) {
     for (i in 1:nmode) {
@@ -178,7 +167,7 @@ model {
   /* Likelihood */
   if ( only_prior == 0 ) {
       for (i in 1:nobs) {
-        strain[i] ~ multi_normal_cholesky(h_det[i], drift[i]*L[i]);
+        strain[i] ~ multi_normal_cholesky(h_det[i], L[i]);
       }
   }
 }

--- a/ringdown/stan/ringdown_mchi_aligned.stan
+++ b/ringdown/stan/ringdown_mchi_aligned.stan
@@ -54,9 +54,6 @@ data {
   real cosi_min;
   real cosi_max;
 
-  real dt_min;
-  real dt_max;
-
   real df_max;
   real dtau_max;
 
@@ -76,8 +73,6 @@ parameters {
 
   vector[nmode] Ax_unit;
   vector[nmode] Ay_unit;
-
-  vector<lower=dt_min, upper=dt_max>[nobs-1] dts;
 
   vector<lower=-df_max,upper=df_max>[nmode] df;
   vector<lower=-dtau_max,upper=dtau_max>[nmode] dtau;
@@ -118,14 +113,8 @@ transformed parameters {
     real torigin;
     h_det[i] = rep_vector(0.0, nsamp);
 
-    if (i > 1) {
-      torigin = t0[i] + dts[i-1];
-    } else {
-      torigin = t0[i];
-    }
-
     for (j in 1:nmode) {
-      h_det_mode[i, j] = rd(times[i] - torigin, f[j], gamma[j], A[j], cosi, phi[j], FpFc[i][1], FpFc[i][2]);
+      h_det_mode[i, j] = rd(times[i] - t0[i], f[j], gamma[j], A[j], cosi, phi[j], FpFc[i][1], FpFc[i][2]);
       h_det[i] = h_det[i] + h_det_mode[i,j];
     }
   }

--- a/ringdown/stan/ringdown_mchi_aligned.stan
+++ b/ringdown/stan/ringdown_mchi_aligned.stan
@@ -51,8 +51,6 @@ data {
 
   real A_scale;
   
-  real drift_scale;
-
   real cosi_min;
   real cosi_max;
 
@@ -71,7 +69,6 @@ data {
 }
 
 parameters {
-  real log_drift_unit[nobs];
   real<lower=M_min, upper=M_max> M;
   real<lower=chi_min, upper=chi_max> chi;
   real<lower=cosi_min, upper=cosi_max> cosi;
@@ -87,7 +84,6 @@ parameters {
 }
 
 transformed parameters {
-  real drift[nobs];
   vector[nmode] gamma;
   vector[nmode] f;
   vector[nsamp] h_det_mode[nobs,nmode];
@@ -96,10 +92,6 @@ transformed parameters {
 
   vector[nmode] A;
   real phi[nmode];
-
-  for (i in 1:nobs) {
-    drift[i] = exp(log_drift_unit[i]*drift_scale);
-  }
 
   for (i in 1:nmode) {
     A[i] = A_scale*sqrt(Ax_unit[i]^2 + Ay_unit[i]^2);
@@ -140,9 +132,6 @@ transformed parameters {
 }
 
 model {
-  /* drift[i] ~ lognormal(0, drift_scale); */
-  log_drift_unit ~ std_normal();
-
   /* Amplitude prior */
   if (flat_A) {
       for (i in 1:nmode) {
@@ -160,7 +149,7 @@ model {
   /* Likelihood */
   if ( only_prior == 0 ) {
       for (i in 1:nobs) {
-        strain[i] ~ multi_normal_cholesky(h_det[i], drift[i]*L[i]);
+        strain[i] ~ multi_normal_cholesky(h_det[i], L[i]);
       }
   }
 }

--- a/ringdown/stan/ringdown_mchi_charged.stan
+++ b/ringdown/stan/ringdown_mchi_charged.stan
@@ -48,8 +48,6 @@ data {
   real M_max;
   real A_scale;
 
-  real drift_scale;
-
   real dt_min;
   real dt_max;
 
@@ -69,7 +67,6 @@ transformed data {
 }
 
 parameters {
-  real log_drift_unit[nobs];
   real<lower=M_min, upper=M_max> M;
   real<lower=r2_qchi_min, upper=r2_qchi_max> r2_qchi;
   real<lower=theta_qchi_min, upper=theta_qchi_max> theta_qchi;
@@ -85,7 +82,6 @@ parameters {
 transformed parameters {
   real q;
   real chi;
-  real drift[nobs];
   vector[nmode] gamma;
   vector[nmode] f;
   vector[nsamp] h_det_mode[nobs,nmode];
@@ -98,10 +94,6 @@ transformed parameters {
 
   vector[nmode] A;
   vector[nmode] ellip;
-
-  for (i in 1:nobs) {
-    drift[i] = exp(log_drift_unit[i]*drift_scale);
-  }
 
   for (i in 1:nmode) {
     Apx[i] = A_scale*Apx_unit[i];
@@ -155,9 +147,6 @@ transformed parameters {
 }
 
 model {
-  /* drift ~ lognormal(0, drift_scale) */
-  log_drift_unit ~ std_normal();
-
   /* Amplitude prior */
   if (flat_A) {
     for (i in 1:nmode) {
@@ -181,7 +170,7 @@ model {
   /* Likelihood */
   if ( only_prior == 0 ) {
       for (i in 1:nobs) {
-        strain[i] ~ multi_normal_cholesky(h_det[i], drift[i]*L[i]);
+        strain[i] ~ multi_normal_cholesky(h_det[i], L[i]);
       }
   }
 }

--- a/ringdown/stan/ringdown_mchi_charged.stan
+++ b/ringdown/stan/ringdown_mchi_charged.stan
@@ -48,9 +48,6 @@ data {
   real M_max;
   real A_scale;
 
-  real dt_min;
-  real dt_max;
-
   real r2_qchi_min;
   real r2_qchi_max;
 
@@ -75,8 +72,6 @@ parameters {
   vector[nmode] Apy_unit;
   vector[nmode] Acx_unit;
   vector[nmode] Acy_unit;
-
-  vector<lower=dt_min, upper=dt_max>[nobs-1] dts;
 }
 
 transformed parameters {
@@ -132,14 +127,8 @@ transformed parameters {
       real torigin;
       h_det[i] = rep_vector(0.0, nsamp);
 
-      if (i > 1) {
-        torigin = t0[i] + dts[i-1];
-      } else {
-        torigin = t0[i];
-      }
-
     for (j in 1:nmode) {
-      h_det_mode[i, j] = rd(times[i] - torigin, f[j], gamma[j], Apx[j], Apy[j], Acx[j], Acy[j], FpFc[i][1], FpFc[i][2]);
+      h_det_mode[i, j] = rd(times[i] - t0[i], f[j], gamma[j], Apx[j], Apy[j], Acx[j], Acy[j], FpFc[i][1], FpFc[i][2]);
       h_det[i] = h_det[i] + h_det_mode[i,j];
     }
   }

--- a/ringdown/stan/ringdown_mchiq.stan
+++ b/ringdown/stan/ringdown_mchiq.stan
@@ -48,8 +48,6 @@ data {
   real M_max;
   real A_scale;
 
-  real drift_scale;
-
   real dt_min;
   real dt_max;
 
@@ -69,7 +67,6 @@ transformed data {
 }
 
 parameters {
-  real log_drift_unit[nobs];
   real<lower=M_min, upper=M_max> M;
   real<lower=r2_qchi_min, upper=r2_qchi_max> r2_qchi;
   real<lower=theta_qchi_min, upper=theta_qchi_max> theta_qchi;
@@ -85,7 +82,6 @@ parameters {
 transformed parameters {
   real q;
   real chi;
-  real drift[nobs];
   vector[nmode] gamma;
   vector[nmode] f;
   vector[nsamp] h_det_mode[nobs,nmode];
@@ -98,10 +94,6 @@ transformed parameters {
 
   vector[nmode] A;
   vector[nmode] ellip;
-
-  for (i in 1:nobs) {
-    drift[i] = exp(log_drift_unit[i]*drift_scale);
-  }
 
   for (i in 1:nmode) {
     Apx[i] = A_scale*Apx_unit[i];
@@ -155,9 +147,6 @@ transformed parameters {
 }
 
 model {
-  /* drift ~ lognormal(0, drift_scale) */
-  log_drift_unit ~ std_normal();
-
   /* Amplitude prior */
   if (flat_A) {
     for (i in 1:nmode) {
@@ -181,7 +170,7 @@ model {
   /* Likelihood */
   if ( only_prior == 0 ) {
       for (i in 1:nobs) {
-        strain[i] ~ multi_normal_cholesky(h_det[i], drift[i]*L[i]);
+        strain[i] ~ multi_normal_cholesky(h_det[i], L[i]);
       }
   }
 }

--- a/ringdown/stan/ringdown_mchiq.stan
+++ b/ringdown/stan/ringdown_mchiq.stan
@@ -48,9 +48,6 @@ data {
   real M_max;
   real A_scale;
 
-  real dt_min;
-  real dt_max;
-
   real r2_qchi_min;
   real r2_qchi_max;
 
@@ -75,8 +72,6 @@ parameters {
   vector[nmode] Apy_unit;
   vector[nmode] Acx_unit;
   vector[nmode] Acy_unit;
-
-  vector<lower=dt_min, upper=dt_max>[nobs-1] dts;
 }
 
 transformed parameters {
@@ -132,14 +127,8 @@ transformed parameters {
       real torigin;
       h_det[i] = rep_vector(0.0, nsamp);
 
-      if (i > 1) {
-        torigin = t0[i] + dts[i-1];
-      } else {
-        torigin = t0[i];
-      }
-
     for (j in 1:nmode) {
-      h_det_mode[i, j] = rd(times[i] - torigin, f[j], gamma[j], Apx[j], Apy[j], Acx[j], Acy[j], FpFc[i][1], FpFc[i][2]);
+      h_det_mode[i, j] = rd(times[i] - t0[i], f[j], gamma[j], Apx[j], Apy[j], Acx[j], Acy[j], FpFc[i][1], FpFc[i][2]);
       h_det[i] = h_det[i] + h_det_mode[i,j];
     }
   }


### PR DESCRIPTION
Just by removing the psd drift variables.  The reason is that Stan is able to know then that it can treat the covariance matrix cholesky decomp as a float (i.e. it doesn't depend on any parameters), so it doesn't have to autodiff it, which is a significant savings.  (I also removed the `dt` variables, which were also unnecessary.)

I still don't understand why the mass matrix seems to show such strong correlations (the condition number of the mass matrix is something like 100 or 1000, which is quite a wide spread of eigenvalues).  When I look at the eigenvectors that correspond to the "tight" and "wide" dimensions of the covariance, I don't really see anything obvious---they seem to be mash-ups of all the parameters.  So there's probably still some efficiency to gain by re-parameterizing to make the mass matrix more diagonal, if we could just figure out what those parameters *are*.

But a factor of two is enough for tonight, I think.