### PR TITLE
Better, safer ACF computation

### DIFF
--- a/ringdown/data.py
+++ b/ringdown/data.py
@@ -447,6 +447,7 @@ class PowerSpectrum(FrequencySeries):
         """
         fs = kws.pop('fs', 1/getattr(data, 'delta_t', 1))
         kws['nperseg'] = kws.get('nperseg', fs)  # default to 1s segments
+        kws['average'] = kws.get('average', 'median') # default to median-averaged, not mean-averaged to handle outliers.
         freq, psd = sig.welch(data, fs=fs, **kws)
         p = cls(psd, index=freq)
         if flow:

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -20,6 +20,13 @@ from . import qnms
 import warnings
 from . import waveforms
 
+def np2(x):
+    """Returns the next power of two as big as or larger than x."""
+    p = 1
+    while p < x:
+        p = p << 1
+    return p
+
 Target = namedtuple('Target', ['t0', 'ra', 'dec', 'psi'])
 
 MODELS = ('ftau', 'mchi', 'mchi_aligned', 'mchiq')
@@ -796,6 +803,12 @@ class Fit(object):
         ifos = self.ifos if ifos is None else ifos
         if len(ifos) == 0:
             raise ValueError("first add data")
+
+        nperseg_safe = np2(16*self.n_analyze)
+        if kws.get('method', 'fd') == 'fd':
+            if not ('nperseg' in kws):
+                kws['nperseg'] = nperseg_safe
+        
         # if shared, compute a single ACF
         acf = self.data[ifos[0]].get_acf(**kws) if shared else None
         for ifo in ifos:

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -804,10 +804,12 @@ class Fit(object):
         if len(ifos) == 0:
             raise ValueError("first add data")
 
-        nperseg_safe = np2(16*self.n_analyze)
-        if kws.get('method', 'fd') == 'fd':
-            if not ('nperseg' in kws):
-                kws['nperseg'] = nperseg_safe
+        # Try to set a safe `nperseg` if we are using `fd` estimation
+        if self.n_analyze is not None:
+            nperseg_safe = np2(16*self.n_analyze)
+            if kws.get('method', 'fd') == 'fd':
+                if not ('nperseg' in kws):
+                    kws['nperseg'] = nperseg_safe
         
         # if shared, compute a single ACF
         acf = self.data[ifos[0]].get_acf(**kws) if shared else None


### PR DESCRIPTION
* Ensure that at least 16*T (T is analysis segment length) segments are used to compute the ACF when method is 'fd', to avoid "edge" effects from enforced periodicity.
* Use 'median' not 'mean' to "average" segments together.