### PR TITLE
Apply bugfixes for injections

### DIFF
--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -699,7 +699,7 @@ class Fit(object):
 
         # ensure delta_t of ACFs is equal to delta_t of data
         for ifo in self.ifos:
-            if self.acfs[ifo].delta_t != self.data[ifo].delta_t:
+            if not np.isclose(self.acfs[ifo].delta_t, self.data[ifo].delta_t):
                 e = "{} ACF delta_t ({:.1e}) does not match data ({:.1e})."
                 raise AssertionError(e.format(ifo, self.acfs[ifo].delta_t,
                                           self.data[ifo].delta_t))
@@ -762,7 +762,13 @@ class Fit(object):
         residuals = {}
         residuals_stacked = {}
         for ifo in self.ifos:
-            ifo_key = bytes(str(ifo), 'utf-8') # IFO coordinates are bytestrings
+            if ifo in self.result.posterior.ifo:
+                ifo_key = ifo
+            elif bytes(str(ifo), 'utf-8') in self.result.posterior.ifo:
+                # IFO coordinates are bytestrings
+                ifo_key = bytes(str(ifo), 'utf-8') # IFO coordinates are bytestrings
+            else:
+                raise KeyError(f"IFO {ifo} is not a valid indexing ifo for the result posterior")
             r = self.result.observed_data[f'strain_{ifo}'] -\
                 self.result.posterior.h_det.loc[:,:,ifo_key,:]
             residuals[ifo] = r.transpose('chain', 'draw', 'time_index')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='ringdown',
       url='https://github.com/maxisi/ringdown',
       license='MIT',
       packages=find_packages(),
-      package_data={'ringdown': ['stan/*.stan']},
+      #package_data={'ringdown': ['stan/*.stan']},
       scripts=['bin/ringdown_fit', 'bin/ringdown_pipe'],
       install_requires=[
             'arviz',


### PR DESCRIPTION
Hi all - 

For a brief bit of context, I'm a grad student with Alan at Caltech. While working with https://github.com/ddzingel on doing some injection / recover tests with ringdown, a couple bugs cropped up. Namely,

1. When data is created  manually, by e.g. 

```
...
H1_data = TimeSeries(H1_fp*h.real+H1_fc*h.imag,t0=t[0] - H1_delay, dt=sampling_rate)
H1_data = rd.Data(H1_data, index=H1_t, ifo='H1')
fit.add_data(H1_data, acf = acf, ifo="H1")
...
```
Then after fitting the fit object's .posterior.h_det.ifos keys will be simple strings, as oppose to byte representations of the string. Accordingly, I added a conditional to catch this case separately.

2. When acfs are passed (e.g. when computed form a PSD) rather than computed from the data, their delta_t may disagree with that of the data at the level of floating point error. So, I switched the hard equality to an np.isclose; I use the default tolerances, but at least for the issue we were running into those tolerances could be tightened by a few orders of magnitude while still passing the check. 

Finally, I commented out what appears to be a vestigial reference to stan package data which was causing me issues during setup. 

Best,
Rhiannon Udall