### PR TITLE
Sample prior including potentials

### DIFF
--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -197,7 +197,7 @@ class Fit(object):
                 f_max=None,
                 f_min=None,
                 gamma_max=None,
-                gamma_min=None
+                gamma_min=None,
                 prior_run=False
             ))
         elif self.model == 'mchi':
@@ -230,7 +230,7 @@ class Fit(object):
                 cosi_max=1,
                 flat_A=0,
                 f_min=0.0,
-                f_max=np.inf
+                f_max=np.inf,
                 prior_run=False
             ))
         elif self.model == 'mchiq':
@@ -246,7 +246,7 @@ class Fit(object):
                  flat_A=0,
                  flat_A_ellip=0,
                  f_min=0.0,
-                 f_max=np.inf
+                 f_max=np.inf,
                  prior_run=False
              ))
         return default

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -212,7 +212,8 @@ class Fit(object):
                 flat_A=0,
                 flat_A_ellip=0,
                 f_min=0.0,
-                f_max=np.inf
+                f_max=np.inf,
+                prior_run=False
             ))
         elif self.model == 'mchi_aligned':
             default.update(dict(

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -198,6 +198,7 @@ class Fit(object):
                 f_min=None,
                 gamma_max=None,
                 gamma_min=None
+                prior_run=False
             ))
         elif self.model == 'mchi':
             default.update(dict(
@@ -230,6 +231,7 @@ class Fit(object):
                 flat_A=0,
                 f_min=0.0,
                 f_max=np.inf
+                prior_run=False
             ))
         elif self.model == 'mchiq':
              default.update(dict(
@@ -245,6 +247,7 @@ class Fit(object):
                  flat_A_ellip=0,
                  f_min=0.0,
                  f_max=np.inf
+                 prior_run=False
              ))
         return default
 

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -122,6 +122,7 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
     flat_A_ellip = kwargs.pop("flat_A_ellip", False)
     f_min = kwargs.pop('f_min', None)
     f_max = kwargs.pop('f_max', None)
+    prior_run = kwargs.pop('prior_run', False)
 
     if flat_A and flat_A_ellip:
         raise ValueError("at most one of `flat_A` and `flat_A_ellip` can be "
@@ -229,7 +230,11 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
             if isinstance(key, bytes):
                 # Don't want byte strings in our names!
                 key = key.decode('utf-8')
-            _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+            if prior_run:
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+                            observed=None, dims=['time_index'])
+            else:
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -231,7 +231,7 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
                 if isinstance(key, bytes):
                  # Don't want byte strings in our names!
                     key = key.decode('utf-8')
-                    _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model
@@ -366,6 +366,7 @@ def make_ftau_model(t0, times, strains, Ls, **kwargs):
     A_scale = kwargs.pop("A_scale")
     flat_A = kwargs.pop("flat_A", True)
     nmode = kwargs.pop("nmode", 1)
+    prior_run = kwargs.pop('prior_run', False)
 
     ndet = len(t0)
     nt = len(times[0])
@@ -425,12 +426,13 @@ def make_ftau_model(t0, times, strains, Ls, **kwargs):
         # Flat prior on the delta-fs and delta-taus
 
         # Likelihood
-        for i in range(ndet):
-            key = ifos[i]
-            if isinstance(key, bytes):
+        if not prior_run:
+            for i in range(ndet):
+                key = ifos[i]
+                if isinstance(key, bytes):
                 # Don't want byte strings in our names!
-                key = key.decode('utf-8')
-            _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+                   key = key.decode('utf-8')
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -225,16 +225,13 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
         # Flat prior on the delta-fs and delta-taus
 
         # Likelihood:
-        for i in range(ndet):
-            key = ifos[i]
-            if isinstance(key, bytes):
-                # Don't want byte strings in our names!
-                key = key.decode('utf-8')
-            if prior_run:
-                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
-                            observed=None, dims=['time_index'])
-            else:
-                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+        if not prior_run:
+            for i in range(ndet):
+                key = ifos[i]
+                if isinstance(key, bytes):
+                 # Don't want byte strings in our names!
+                    key = key.decode('utf-8')
+                    _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model
@@ -255,6 +252,7 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
     flat_A = kwargs.pop("flat_A", True)
     f_min = kwargs.pop('f_min', 0.0)
     f_max = kwargs.pop('f_max', np.inf)
+    prior_run = kwargs.pop('prior_run',False)
 
 
     if (cosi_min < -1) or (cosi_max > 1):
@@ -346,12 +344,13 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
         # Flat prior on the delta-fs and delta-taus
 
         # Likelihood
-        for i in range(ndet):
-            key = ifos[i]
-            if isinstance(key, bytes):
-                # Don't want byte strings in our names!
-                key = key.decode('utf-8')
-            _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+        if not prior_run:
+            for i in range(ndet):
+                key = ifos[i]
+                if isinstance(key, bytes):
+                    # Don't want byte strings in our names!
+                    key = key.decode('utf-8')
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model


### PR DESCRIPTION
New option to sample directly from likelihood including potentials, to address the fact that currently running fit.run(prior=True) will not show any pm.potential distributions.