### PR TITLE
Sample prior with potentials

### DIFF
--- a/ringdown/data.py
+++ b/ringdown/data.py
@@ -304,7 +304,7 @@ class Data(TimeSeries):
 
     def condition(self, t0=None, ds=None, flow=None, fhigh=None, trim=0.25,
                   digital_filter=False, remove_mean=True, decimate_kws=None,
-                  scipy_dec=None):
+                  scipy_dec=None, slice_left = None, slice_right = None):
         """Condition data.
 
         Arguments
@@ -328,12 +328,23 @@ class Data(TimeSeries):
         trim : float
             fraction of data to trim from edges after conditioning, to avoid
             spectral issues if filtering.
+        slice_left : float
+            number of seconds before t0 to slice the strain data, e.g. to avoid NaNs
+        slice_right : float
+            number of seconds after t0 to slice the strain data, e.g. to avoid NaNs
 
         Returns
         -------
         cond_data : Data
             conditioned data object.
         """
+        if slice_left is not None and slice_right is None:
+            self = self[t0-slice_left:]
+        elif slice_left is None and slice_right is not None:
+            self = self[:t0+slice_right]
+        elif slice_left is not None and slice_right is not None:
+            self = self[t0-slice_left:t0+slice_right]
+
         raw_data = self.values
         raw_time = self.index.values
 

--- a/ringdown/data.py
+++ b/ringdown/data.py
@@ -434,7 +434,7 @@ class PowerSpectrum(FrequencySeries):
         return PowerSpectrum
 
     @classmethod
-    def from_data(cls, data, flow=None, patch_level=None, **kws):
+    def from_data(cls, data, flow=None, fhigh=None, patch_level=None, **kws):
         """Estimate :class:`PowerSpectrum` from time domain data using Welch's
         method.
 
@@ -444,6 +444,10 @@ class PowerSpectrum(FrequencySeries):
             data time series.
         flow : float, None
             optional lower frequency at which to taper PSD via
+            :meth:`PowerSpectrum.flatten`. Defaults to None (i.e., no
+            flattening).
+        fhigh : float, None
+            optional higher frequency at which to taper PSD via
             :meth:`PowerSpectrum.flatten`. Defaults to None (i.e., no
             flattening).
         smooth : bool
@@ -461,8 +465,8 @@ class PowerSpectrum(FrequencySeries):
         kws['average'] = kws.get('average', 'median') # default to median-averaged, not mean-averaged to handle outliers.
         freq, psd = sig.welch(data, fs=fs, **kws)
         p = cls(psd, index=freq)
-        if flow:
-            p.flatten(flow, patch_level=patch_level, inplace=True)
+        if flow is not None or fhigh is not None:
+            p.flatten(flow=flow, fhigh=fhigh, patch_level=patch_level, inplace=True)
         return p
 
     @classmethod
@@ -534,6 +538,7 @@ class PowerSpectrum(FrequencySeries):
         psd = self if inplace else self.copy()
         # determine highest frequency
         f = psd.freq
+        flow = max(flow or min(f), min(f))
         fhigh = min(fhigh or max(f), max(f))
         # create tuple (patch_level_low, patch_level_high)
         if patch_level is None:

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -742,9 +742,8 @@ class Fit(object):
                             kws['draws'] = draws
 
                             self.run(prior=prior, suppress_warnings=suppress_warnings, store_residuals=store_residuals, min_ess=min_ess, **kws)
-        if not prior:
-            if store_residuals:
-                self._generate_whitened_residuals()
+        if not prior and store_residuals:
+            self._generate_whitened_residuals()
     run.__doc__ = run.__doc__.format(DEF_RUN_KWS)
 
     def _generate_whitened_residuals(self):

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -388,12 +388,16 @@ class Fit(object):
                 try:
                     return literal_eval(x)
                 except (TypeError,ValueError,SyntaxError):
-                    return x
+                    if x == "inf":
+                        return np.inf
+                    else:
+                        return x
+                    
         # create fit object
         fit = cls(config['model']['name'], modes=config['model']['modes'])
         # add priors
         prior = config['prior']
-        fit.update_prior(**{k: literal_eval(v) for k,v in prior.items()
+        fit.update_prior(**{k: try_parse(v) for k,v in prior.items()
                              if "drift" not in k})
         if 'data' not in config:
             # the rest of the options require loading data, so if no pointer to

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -197,7 +197,7 @@ class Fit(object):
                 f_max=None,
                 f_min=None,
                 gamma_max=None,
-                gamma_min=None
+                gamma_min=None,
                 prior_run=False
             ))
         elif self.model == 'mchi':
@@ -230,7 +230,7 @@ class Fit(object):
                 cosi_max=1,
                 flat_A=0,
                 f_min=0.0,
-                f_max=np.inf
+                f_max=np.inf,
                 prior_run=False
             ))
         elif self.model == 'mchiq':
@@ -246,7 +246,7 @@ class Fit(object):
                  flat_A=0,
                  flat_A_ellip=0,
                  f_min=0.0,
-                 f_max=np.inf
+                 f_max=np.inf,
                  prior_run=False
              ))
         return default

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -212,7 +212,8 @@ class Fit(object):
                 flat_A=0,
                 flat_A_ellip=0,
                 f_min=0.0,
-                f_max=np.inf
+                f_max=np.inf,
+                prior_run=False
             ))
         elif self.model == 'mchi_aligned':
             default.update(dict(

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -198,6 +198,7 @@ class Fit(object):
                 f_min=None,
                 gamma_max=None,
                 gamma_min=None
+                prior_run=False
             ))
         elif self.model == 'mchi':
             default.update(dict(
@@ -230,6 +231,7 @@ class Fit(object):
                 flat_A=0,
                 f_min=0.0,
                 f_max=np.inf
+                prior_run=False
             ))
         elif self.model == 'mchiq':
              default.update(dict(
@@ -245,6 +247,7 @@ class Fit(object):
                  flat_A_ellip=0,
                  f_min=0.0,
                  f_max=np.inf
+                 prior_run=False
              ))
         return default
 

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -211,6 +211,8 @@ class Fit(object):
                 chi_max=0.99,
                 flat_A=0,
                 flat_A_ellip=0,
+                f_min=0.0,
+                f_max=np.inf
             ))
         elif self.model == 'mchi_aligned':
             default.update(dict(
@@ -225,6 +227,8 @@ class Fit(object):
                 cosi_min=-1,
                 cosi_max=1,
                 flat_A=0,
+                f_min=0.0,
+                f_max=np.inf
             ))
         elif self.model == 'mchiq':
              default.update(dict(
@@ -237,7 +241,9 @@ class Fit(object):
                  df_coeffs=[],
                  dg_coeffs=[],
                  flat_A=0,
-                 flat_A_ellip=0
+                 flat_A_ellip=0,
+                 f_min=0.0,
+                 f_max=np.inf
              ))
         return default
 

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -122,6 +122,7 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
     flat_A_ellip = kwargs.pop("flat_A_ellip", False)
     f_min = kwargs.pop('f_min', None)
     f_max = kwargs.pop('f_max', None)
+    prior_run = kwargs.pop('prior_run', False)
 
     if flat_A and flat_A_ellip:
         raise ValueError("at most one of `flat_A` and `flat_A_ellip` can be "
@@ -229,7 +230,11 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
             if isinstance(key, bytes):
                 # Don't want byte strings in our names!
                 key = key.decode('utf-8')
-            _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+            if prior_run:
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+                            observed=None, dims=['time_index'])
+            else:
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -244,7 +244,8 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
                 _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         else:
-            samp_prior_cond = pm.Potential('A_prior', at.sum(at.where(A > 10*A_scale, np.NINF, 0.0)))
+            print("Sampling prior")
+            samp_prior_cond = pm.Potential('A_prior', at.sum(at.where(A > (10*A_scale or 1e-19), np.NINF, 0.0))) #this condition is to bound flat priors just for sampling from the prior
 
         
         return model
@@ -365,6 +366,9 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
                     key = key.decode('utf-8')
                 _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
+        else:
+            print("Sampling prior")
+            samp_prior_cond = pm.Potential('A_prior', at.sum(at.where(A > (10*A_scale or 1e-19), np.NINF, 0.0))) #this condition is to bound flat priors just for sampling from the prior
         
         return model
 
@@ -447,6 +451,9 @@ def make_ftau_model(t0, times, strains, Ls, **kwargs):
                    key = key.decode('utf-8')
                 _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
+        else:
+            print("Sampling prior")
+            samp_prior_cond = pm.Potential('A_prior', at.sum(at.where(A > (10*A_scale or 1e-19), np.NINF, 0.0))) #this condition is to bound flat priors just for sampling from the prior
         
         return model
 

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -308,8 +308,10 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
         # Check limits on f
         if not np.isscalar(f_min) or not f_min == 0.0:
             _ = pm.Potential('f_min_cut', at.sum(at.where(f < f_min, np.NINF, 0.0)))
+            print("Running with f_min_cut on modes:",f_min)
         if not np.isscalar(f_max) or not f_max == np.inf:
             _ = pm.Potential('f_max_cut', at.sum(at.where(f > f_max, np.NINF, 0.0)))
+            print("Running with f_max_cut on modes:",f_max)
 
 
         Apx = (1 + at.square(cosi))*A*at.cos(phi)

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -231,7 +231,7 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
                 if isinstance(key, bytes):
                  # Don't want byte strings in our names!
                     key = key.decode('utf-8')
-                    _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model
@@ -366,6 +366,7 @@ def make_ftau_model(t0, times, strains, Ls, **kwargs):
     A_scale = kwargs.pop("A_scale")
     flat_A = kwargs.pop("flat_A", True)
     nmode = kwargs.pop("nmode", 1)
+    prior_run = kwargs.pop('prior_run', False)
 
     ndet = len(t0)
     nt = len(times[0])
@@ -425,12 +426,13 @@ def make_ftau_model(t0, times, strains, Ls, **kwargs):
         # Flat prior on the delta-fs and delta-taus
 
         # Likelihood
-        for i in range(ndet):
-            key = ifos[i]
-            if isinstance(key, bytes):
+        if not prior_run:
+            for i in range(ndet):
+                key = ifos[i]
+                if isinstance(key, bytes):
                 # Don't want byte strings in our names!
-                key = key.decode('utf-8')
-            _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+                   key = key.decode('utf-8')
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -188,9 +188,9 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
         phi = pm.Deterministic("phi", 0.5*(phiR - phiL), dims=['mode'])
 
         # Check limits on f
-        if f_min is not None:
+        if not np.isscalar(f_min) or not f_min == 0.0:
             _ = pm.Potential('f_min_cut', at.sum(at.where(f < f_min, np.NINF, 0.0)))
-        if f_max is not None:
+        if not np.isscalar(f_max) or not f_max == np.inf:
             _ = pm.Potential('f_max_cut', at.sum(at.where(f > f_max, np.NINF, 0.0)))
 
         h_det_mode = pm.Deterministic("h_det_mode",
@@ -248,8 +248,8 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
     perturb_f = kwargs.pop("perturb_f", 0)
     perturb_tau = kwargs.pop("perturb_tau", 0)
     flat_A = kwargs.pop("flat_A", True)
-    f_min = kwargs.pop('f_min', None)
-    f_max = kwargs.pop('f_max', None)
+    f_min = kwargs.pop('f_min', 0.0)
+    f_max = kwargs.pop('f_max', np.inf)
 
 
     if (cosi_min < -1) or (cosi_max > 1):
@@ -306,9 +306,9 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
         ellip = pm.Deterministic('ellip', Ac/Ap, dims=['mode'])
 
         # Check limits on f
-        if f_min is not None:
+        if not np.isscalar(f_min) or not f_min == 0.0:
             _ = pm.Potential('f_min_cut', at.sum(at.where(f < f_min, np.NINF, 0.0)))
-        if f_max is not None:
+        if not np.isscalar(f_max) or not f_max == np.inf:
             _ = pm.Potential('f_max_cut', at.sum(at.where(f > f_max, np.NINF, 0.0)))
 
 

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -230,7 +230,7 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
                                                   Acx_unit, Acy_unit,flat_A_ellip))
             # bring us to flat-in-A and flat-in-ellip prior
             pm.Potential("flat_A_ellip_prior", 
-                         at.sum((-3*at.log(A) - at.log1m(at.square(ellip))*flat_A_ellip)))
+                         at.sum((-3*at.log(A) - at.log1m(at.square(ellip)))*flat_A_ellip))
 
         # Flat prior on the delta-fs and delta-taus
 
@@ -243,6 +243,9 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
                     key = key.decode('utf-8')
                 _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
+        else:
+            samp_prior_cond = pm.Potential('A_prior', at.sum(at.where(A > 10*A_scale, np.NINF, 0.0)))
+
         
         return model
         

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -266,8 +266,8 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
     flat_A = kwargs.pop("flat_A", True)
     f_min = kwargs.pop('f_min', 0.0)
     f_max = kwargs.pop('f_max', np.inf)
-    nmode = f_coeffs.shape[0]
     prior_run = kwargs.pop('prior_run',False)
+    nmode = f_coeffs.shape[0]
 
 
     if (cosi_min < -1) or (cosi_max > 1):

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -225,16 +225,13 @@ def make_mchi_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs, g_coeffs,
         # Flat prior on the delta-fs and delta-taus
 
         # Likelihood:
-        for i in range(ndet):
-            key = ifos[i]
-            if isinstance(key, bytes):
-                # Don't want byte strings in our names!
-                key = key.decode('utf-8')
-            if prior_run:
-                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
-                            observed=None, dims=['time_index'])
-            else:
-                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+        if not prior_run:
+            for i in range(ndet):
+                key = ifos[i]
+                if isinstance(key, bytes):
+                 # Don't want byte strings in our names!
+                    key = key.decode('utf-8')
+                    _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model
@@ -255,6 +252,7 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
     flat_A = kwargs.pop("flat_A", True)
     f_min = kwargs.pop('f_min', 0.0)
     f_max = kwargs.pop('f_max', np.inf)
+    prior_run = kwargs.pop('prior_run',False)
 
 
     if (cosi_min < -1) or (cosi_max > 1):
@@ -346,12 +344,13 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
         # Flat prior on the delta-fs and delta-taus
 
         # Likelihood
-        for i in range(ndet):
-            key = ifos[i]
-            if isinstance(key, bytes):
-                # Don't want byte strings in our names!
-                key = key.decode('utf-8')
-            _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
+        if not prior_run:
+            for i in range(ndet):
+                key = ifos[i]
+                if isinstance(key, bytes):
+                    # Don't want byte strings in our names!
+                    key = key.decode('utf-8')
+                _ = pm.MvNormal(f"strain_{key}", mu=h_det[i,:], chol=Ls[i],
                             observed=strains[i], dims=['time_index'])
         
         return model

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -266,6 +266,7 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
     flat_A = kwargs.pop("flat_A", True)
     f_min = kwargs.pop('f_min', 0.0)
     f_max = kwargs.pop('f_max', np.inf)
+    nmode = f_coeffs.shape[0]
     prior_run = kwargs.pop('prior_run',False)
 
 
@@ -276,7 +277,6 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
     
     ndet = len(t0)
     nt = len(times[0])
-    nmode = f_coeffs.shape[0]
 
     ifos = kwargs.pop('ifos', np.arange(ndet))
     modes = kwargs.pop('modes', np.arange(nmode))

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -266,8 +266,8 @@ def make_mchi_aligned_model(t0, times, strains, Ls, Fps, Fcs, f_coeffs,
     flat_A = kwargs.pop("flat_A", True)
     f_min = kwargs.pop('f_min', 0.0)
     f_max = kwargs.pop('f_max', np.inf)
-    prior_run = kwargs.pop('prior_run',False)
     nmode = f_coeffs.shape[0]
+    prior_run = kwargs.pop('prior_run',False)
 
 
     if (cosi_min < -1) or (cosi_max > 1):


### PR DESCRIPTION
Replaced pm.sample_prior_predictive() for fit.run(prior=True) with a prior_run flag in prior_settings of all models, which gets updated to true at run. This allows for sampling of the prior that includes any pm.potential terms.

Note: This branch is also merged with the mixed Gaussian and flat prior branch from my other PR today.