### PR TITLE
Update to pymc5, for python 3.11 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymc==4
+pymc
 aesara
 numpy
 h5py

--- a/ringdown/data.py
+++ b/ringdown/data.py
@@ -15,6 +15,7 @@ import pandas as pd
 import h5py
 import os
 import logging
+import inspect
 
 class Series(pd.Series):
     """ A wrapper of :class:`pandas.Series` with some additional functionality.

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -464,7 +464,7 @@ class Fit(object):
                                      f"with config: {overlap}")
                     # merge injection settings from JSON and INI
                     # NOTE: config file overwrites JSON!
-                    file_kws.update(inj_kws)
+                    json_kws.update(inj_kws)
                     inj_kws = json_kws
                 except (UnicodeDecodeError,json.JSONDecodeError):
                     raise IOError(f"unable to read JSON file: {injpath}")

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -1,7 +1,7 @@
 __all__ = ['make_mchi_model', 'make_mchi_aligned_model', 'make_ftau_model']
 
-import aesara.tensor as at
-import aesara.tensor.slinalg as atl
+import pytensor.tensor as at
+import pytensor.tensor.slinalg as atl
 import numpy as np
 import pymc as pm
 

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -631,7 +631,7 @@ def make_ftau_model(t0, times, strains, Ls, **kwargs):
 
         f = pm.Uniform("f", f_min, f_max, dims=['mode'])
         gamma = pm.Uniform('gamma', gamma_min, gamma_max, dims=['mode'],
-                           transform=pm.distributions.transforms.ordered)
+                           transform=pm.distributions.transforms.Ordered)
 
         Ax_unit = pm.Normal("Ax_unit", dims=['mode'])
         Ay_unit = pm.Normal("Ay_unit", dims=['mode'])

--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -631,7 +631,7 @@ def make_ftau_model(t0, times, strains, Ls, **kwargs):
 
         f = pm.Uniform("f", f_min, f_max, dims=['mode'])
         gamma = pm.Uniform('gamma', gamma_min, gamma_max, dims=['mode'],
-                           transform=pm.distributions.transforms.Ordered)
+                           transform=pm.distributions.transforms.multivariate_ordered)
 
         Ax_unit = pm.Normal("Ax_unit", dims=['mode'])
         Ay_unit = pm.Normal("Ay_unit", dims=['mode'])

--- a/ringdown/waveforms/coalescence.py
+++ b/ringdown/waveforms/coalescence.py
@@ -3,12 +3,15 @@ __all__ = ['Coalescence', 'Parameters']
 from pylab import *
 import lal
 from .core import *
+from ..data import Data
 from scipy.signal import tukey
 import lal
 import lalsimulation as ls
 from dataclasses import dataclass, asdict, fields
 import inspect
 import h5py
+import pandas as pd
+import warnings
 
 def docstring_parameter(*args, **kwargs):
     def dec(obj):


### PR DESCRIPTION
Currently, pymc is pinned to v4. However, this in turn prevents from updating to python3.11. pymc5 requires a dropin replacement of aesara-->pytensor, as referenced [here](https://discourse.pymc.io/t/pymc-4-aesara-cannot-convert-elemwise-pow-no-inplace-0-to-a-tensor-variable/11436/2), and a switch from `pm.distributions.transforms.ordered` to `pm.distributions.transforms.multivariate_ordered`,  but is otherwise entirely compatible with ringdown in its present form. Having made this change I tested with the GW150914.ipynb standard example notebook, and found everything to be working fine.