### PR TITLE
Jaxifying the aligned model

### DIFF
--- a/ringdown/swsh.ipynb
+++ b/ringdown/swsh.ipynb
@@ -1,0 +1,349 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax.numpy as jnp\n",
+    "import jax.scipy as jsp\n",
+    "from jax.scipy.special import factorial as fac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "JAX does factorial for tensors, or jax arrays, on its own! No more need for `tens_factorial`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "JAX vectorizes everything, so functions using `jnp` arrays are automatically tensorized. `jax_binom_coeff` turns `tens_binom` into (basically) one line:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def jax_binom_coeff(n, k):\n",
+    "    \"\"\"Returns binomial coefficient, `n choose k`.\n",
+    "    \n",
+    "    Arguments\n",
+    "    ---------\n",
+    "    n: int\n",
+    "      number of possibilities\n",
+    "    k: int\n",
+    "      number of unordered outcomes to choose\n",
+    "    \"\"\"\n",
+    "\n",
+    "    coeff = fac(n) / (fac(k) * fac(n-k)) \n",
+    "\n",
+    "    check_nk = jnp.isinf(coeff) # check if k > n, set answer to zero\n",
+    "\n",
+    "    coeff = coeff.at[jnp.array(check_nk)].set(0)\n",
+    "\n",
+    "    return coeff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sp_w_ylm(s, l, m):\n",
+    "    \"\"\"Returns spin-weighted (l, m) spherical harmonic with spin weight s, as a function of cosi.\n",
+    "     \n",
+    "    Arguments\n",
+    "    ---------\n",
+    "    s: int\n",
+    "        spin weight of the sYlm, -2 for GWs\n",
+    "    l: JAX array\n",
+    "        l index of each QNM to be included in the model\n",
+    "    m: JAX array\n",
+    "        l index of each QNM to be included in the model\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    ## with phi = 0\n",
+    "    ## th == np.arccos(cosi)\n",
+    "    \n",
+    "    r = l - s\n",
+    "    \n",
+    "    def _get_rs(r):\n",
+    "        shape = len(r)\n",
+    "        leng = max(r) + 1\n",
+    "        coll = jnp.broadcast_to(jnp.arange(leng), (shape, leng)).swapaxes(0,1)\n",
+    "\n",
+    "        return coll\n",
+    "    \n",
+    "    rs = _get_rs(r)\n",
+    "    \n",
+    "    def sin_th_2(cosi):\n",
+    "        return jnp.sqrt((1-cosi)/2)\n",
+    "    \n",
+    "    def cos_th_2(cosi):\n",
+    "        return jnp.sqrt((1+cosi)/2)\n",
+    "    \n",
+    "    def cot_th_2(cosi):\n",
+    "        return cos_th_2(cosi)/sin_th_2(cosi)\n",
+    "\n",
+    "    ## normalization constant is \\sqrt{1/0.159)} ##\n",
+    "    \n",
+    "    return lambda cosi: ((-1)**(l+m-s) * jnp.sqrt(fac(l+m)*\n",
+    "                                                  fac(l-m)*\n",
+    "                                                  ((2*l)+1)/\n",
+    "                                                  (4*jnp.pi)/\n",
+    "                                                  fac(l+s)/\n",
+    "                                                  fac(l-s)) * (sin_th_2(cosi))**(2*l) * jnp.sum(jnp.array([(-1)**n * jax_binom_coeff(l-s, n) * jax_binom_coeff(l+s, n+s-m) * (cot_th_2(cosi))**((2*n)+s-m) \n",
+    "                                                                                                                            for n in rs]), axis=0)* jnp.sqrt(1/0.159))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[-0.52642703]\n",
+      "[1.0274793]\n",
+      "[-0.52642703  1.0274793 ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sp_w_ylm(-2, jnp.array([3]), jnp.array([2]))(0.5))\n",
+    "print(sp_w_ylm(-2, jnp.array([2]), jnp.array([1]))(0.5))\n",
+    "print(sp_w_ylm(-2, jnp.array([3, 2]), jnp.array([2, 1]))(0.5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sp_w_ylm_p(cosi, l, m):\n",
+    "    \"\"\"Returns (+) spin-weighted angular factor\"\"\"\n",
+    "    return (sp_w_ylm(-2, l, m)(cosi) + sp_w_ylm(-2, l, m)(-cosi)) * jnp.sqrt(5/jnp.pi) # sqrt(5/pi) to match normalization in Isi & Farr (2021)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sp_w_ylm_c(cosi, l, m):\n",
+    "    \"\"\"Returns (x) spin-weighted angular factor\"\"\"\n",
+    "    return (sp_w_ylm(-2, l, m)(cosi) - sp_w_ylm(-2, l, m)(jnp.cos(jnp.pi-jnp.arccos(cosi)))) * jnp.sqrt(5/jnp.pi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above matches the the SWSH calculations that were written up using `aesara`! Ready for implementation in `ringdown` jaxify branch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cosi = 0.5\n",
+    "l = jnp.array([2])\n",
+    "m = jnp.array([2])\n",
+    "\n",
+    "p = sp_w_ylm_p(cosi, l, m)\n",
+    "c = sp_w_ylm_c(cosi, l, m)\n",
+    "\n",
+    "hcp = (1 + (cosi)**2)\n",
+    "hcc = 2 * cosi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JAX (+) angular factor : hardcoded (+) angular factor = 0.997840404510498\n",
+      "JAX (x) angular factor : hardcoded (x) angular factors = 0.9978403449058533\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'JAX (+) angular factor : hardcoded (+) angular factor = {(p/hcp)[0]}')\n",
+    "print(f'JAX (x) angular factor : hardcoded (x) angular factors = {(c/hcc)[0]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num = jnp.abs(sp_w_ylm(-2, jnp.array([4, 3, 2, 2]), jnp.array([4, 2, 1, 0]))(0.5)) - jnp.abs(jnp.conjugate(sp_w_ylm(-2, jnp.array([4, 3, 2, 2]), jnp.array([4, 2, 1, 0]))(-0.5)))\n",
+    "den = jnp.abs(sp_w_ylm(-2, jnp.array([4, 3, 2, 2]), jnp.array([4, 2, 1, 0]))(0.5)) + jnp.abs(jnp.conjugate(sp_w_ylm(-2, jnp.array([4, 3, 2, 2]), jnp.array([4, 2, 1, 0]))(-0.5)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([8.0000001e-01, 1.2500052e-01, 5.0000006e-01, 8.2039314e-08],      dtype=float32)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "num/den"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([8.0000001e-01, 1.2500054e-01, 5.0000006e-01, 8.2039314e-08],      dtype=float32)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sp_w_ylm_c(0.5, jnp.array([4, 3, 2, 2]), jnp.array([4, 2, 1, 0]))/sp_w_ylm_p(0.5, jnp.array([4, 3, 2, 2]), jnp.array([4, 2, 1, 0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "swsh = sp_w_ylm(-2, jnp.array([3, 2]), jnp.array([2, 1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([-0.25856543,  0.5711278 ], dtype=float32)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(swsh(0.3) - swsh(-0.3)) * jnp.sqrt(5/jnp.pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([-0.25856543,  0.5711278 ], dtype=float32)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sp_w_ylm_c(0.3, jnp.array([3, 2]), jnp.array([2, 1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cosi_min: 0.3, cosi_max: 0.99\n"
+     ]
+    }
+   ],
+   "source": [
+    "cosi_min = 0.3\n",
+    "cosi_max = None\n",
+    "\n",
+    "if cosi_min is None and cosi_max is not None:\n",
+    "    cosi_min=-0.99\n",
+    "if cosi_min is not None and cosi_max is None:\n",
+    "    cosi_max = 0.99\n",
+    "\n",
+    "print(f'cosi_min: {cosi_min}, cosi_max: {cosi_max}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rd_jax",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is a complete implementation of the jaxified `aligned` and `aligned_marginal` models. All additions and changes to the model are housed within `model.py`. I have also included a notebook, `swsh.ipynb`, to demo the code for the spin-weighted spherical harmonics and (+)/(x) angular factors required for the reflection symmetry constraints of the aligned-spin models. 

All changes to other files in the upstream/jaxify branch have been synced and merged prior to commiting.