### PR TITLE
Fixing ellipticity calculation for aligned model

### DIFF
--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -205,7 +205,7 @@ def get_quad_derived_quantities(nmodes, design_matrices, quads, a_scale, YpYc,
         a = numpyro.deterministic('a', a_scale * a_norm)
         numpyro.deterministic('phi', jnp.arctan2(ay_unit, ax_unit))
         if YpYc is not None:
-            numpyro.deterministic('ellip', YpYc[1]/YpYc[0])
+            numpyro.deterministic('ellip', YpYc[2])
         # theta = 0 for the aligned model
         # ellip = 0 and theta = 0,pi/2 for the single polarization model
     else:

--- a/ringdown/utils/swsh.py
+++ b/ringdown/utils/swsh.py
@@ -88,9 +88,10 @@ def construct_sYlm(s : int,
     return ylm
 
 def calc_YpYc(cosi, swsh):
-    """Returns + and x angular factors for aligned model"""
+    """Returns + and x angular factors for aligned model, as well as ellipticity for the set of QNMs in the model"""
     ylm_p = swsh(cosi)
     ylm_m = swsh(-cosi)
     Yp = ylm_p + ylm_m
     Yc = ylm_p - ylm_m
-    return Yp, Yc
+    ellip = (jnp.abs(ylm_p) - jnp.abs(ylm_m)) / (jnp.abs(ylm_p) + jnp.abs(ylm_m))
+    return Yp, Yc, ellip


### PR DESCRIPTION
I have made a slight modification to the `calc_YpYc()` function in `utils/swsh.py` such that it also returns the correctly calculated ellipticity for each QNM from the `ylm_p` and `ylm_m` angular factors. In `model.py` there is subsequently only one small change, where the quad-derived quantity `ellip` in the aligned model is simply equal to `YpYc[2]`.

I have tested the fix by running on GW190521's ringdown using the aligned model with modes {220, 210, 320}, and the resulting ellipticity posteriors for each QNM look physical (no longer a delta function due to a zero denominator from miscalculation). 