### PR TITLE
fix 'frametype unknown keyword' error when loading data from .gwf

### DIFF
--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -1039,16 +1039,16 @@ class Fit(object):
             channel_dict = {k: None for k in path_dict.keys()}
         else:
             channel_dict = utils.get_dict_from_pattern(channel, ifos)
-        
-        if frametype is None:
-            frametype_dict = {k: None for k in path_dict.keys()}
-        else:
-            frametype_dict = utils.get_dict_from_pattern(frametype, ifos)
             
         tslide = kws.pop('slide', {}) or {}
         for ifo, path in path_dict.items():
-            self.add_data(Data.load(path, ifo=ifo, channel=channel_dict[ifo],
-                                    frametype=frametype_dict[ifo], **kws))
+            if frametype is None:
+                self.add_data(Data.load(path, ifo=ifo, channel=channel_dict[ifo], **kws))
+                frametype_dict = {k: None for k in path_dict.keys()}
+            else:
+                frametype_dict = utils.get_dict_from_pattern(frametype, ifos)
+                self.add_data(Data.load(path, ifo=ifo, channel=channel_dict[ifo],
+                                        frametype=frametype_dict[ifo], **kws))
         # apply time slide if requested
         for i, dt in tslide.items():
             d = self.data[i]


### PR DESCRIPTION
Previously, when trying to load data from a `.gwf` frame file into a `Fit` object via `ringdown.Fit.load_data()`, the function call threw an unexpected keyword error for the `frametype` argument. This happened because `load_data()` contains calls to `add_data()` that were hard-coded to include the `frametype` keyword arg, which is otherwise optional in the `load_data()` call _and isn't used if loading data from a frame._ The conflict arose in the `read()` method in `data.py` since it calls `gwpy.timeseries.TimeSeries.read()`, which does not take `frametype` as an argument.

To fix this issue, I just rearranged some of logic so that if `'kind'=frame` in the `load_data()` call, the call to `add_data()` doesn't include the `frametype` argument.