### PR TITLE
Fixed ifo key error in indexing observed_strain during LOO computation

### DIFF
--- a/ringdown/result.py
+++ b/ringdown/result.py
@@ -453,7 +453,7 @@ class Result(az.InferenceData):
         residuals = {}
         residuals_stacked = {}
         for ifo in self.ifos.values.astype(str):
-            r = self.observed_strain.sel(ifo=ifo) -\
+            r = self.observed_strain[list(self.ifos.values.astype(str)).index(ifo)] -\
                 self.h_det.sel(ifo=ifo)
             residuals[ifo] = r.transpose('chain', 'draw', 'time_index')
             residuals_stacked[ifo] = residuals[ifo].stack(sample=['chain',


### PR DESCRIPTION
I was still experiencing an error in the LOO computation in `result.py` after the recent bug fix---this was a key error for the key `'ifo'` when using the `sel()` method in indexing the `observed_strain` within the result object.

I bypassed this by using plain array indexing (for now) in the `_generate_whitened_residuals()` method.