### PR TITLE
Fixed typo in GW190521 example

### DIFF
--- a/docs/examples/GW190521.ipynb
+++ b/docs/examples/GW190521.ipynb
@@ -13,7 +13,7 @@
    "id": "67711d92",
    "metadata": {},
    "source": [
-    "We demonstrate how to use `ringdown` to fit damped sinusoids in data from GW190521. We will fit a model composed of two long-lived (fundamental) modes, following [Siegel et al. (2023)](https://arxiv.org/abs/2307.11975). We will also use this as an example for loading open data directly from the Gravitational Wave Open Science Center (GWOSC) using [GWpy](http://gwpy.github.io)."
+    "We demonstrate how to use `ringdown` to fit damped sinusoids in data from GW190521. We will fit a model composed of three long-lived (fundamental) modes, following [Siegel et al. (2023)](https://arxiv.org/abs/2307.11975). We will also use this as an example for loading open data directly from the Gravitational Wave Open Science Center (GWOSC) using [GWpy](http://gwpy.github.io)."
    ]
   },
   {
@@ -1160,7 +1160,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('ringdown')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1174,7 +1174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.10.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Fixing a typo in the GW190521 example: the intro text says 2 QNMs will be fit, but the actual example fits 3.