### PR TITLE
Reweight to uniform-amplitude prior

### DIFF
--- a/ringdown/result.py
+++ b/ringdown/result.py
@@ -873,7 +873,7 @@ class Result(az.InferenceData):
         Returns
         -------
         new_result : Result
-            result with samples reweighted to a uniform amplitude prior; 
+            result with samples reweighted to a uniform amplitude prior;
             posterior will have stacked chains and draws.
         """
         samples = self.stacked_samples

--- a/ringdown/result.py
+++ b/ringdown/result.py
@@ -231,7 +231,7 @@ class Result(az.InferenceData):
             logging.warning('No maximum amplitude scale found in config')
             amax = self.posterior.a_scale.max().values
         return float(amax)
-    
+
     def get_fit(self, **kwargs):
         """Get a Fit object from the result."""
         if self.config:

--- a/ringdown/result.py
+++ b/ringdown/result.py
@@ -842,7 +842,7 @@ class Result(az.InferenceData):
         else:
             return None
 
-    def reweight_to_uniform_amplitude(self, nsamp: int | None = None,
+    def resample_to_uniform_amplitude(self, nsamp: int | None = None,
                                       prng: int | np.random.Generator
                                       | None = None) -> 'Result':
         """Reweight the posterior to a uniform amplitude prior.

--- a/ringdown/result.py
+++ b/ringdown/result.py
@@ -847,6 +847,17 @@ class Result(az.InferenceData):
                                       | None = None) -> 'Result':
         """Reweight the posterior to a uniform amplitude prior.
 
+        The “primal” posterior has a density :math:`p(a, a_{\\rm scale}) =
+        N(a; 0, a_{\\rm scale}) 1/a_{\\rm scale max}`. The target posterior
+        we want has a density :math:`p(a, a_{\\rm scale}) \\propto
+        \\frac{1}{|a|^{n-1}} \\frac{1}{a_{\\rm scale max}}` for :math:`n`
+        quadratures.
+
+        Therefore the importance weighs are
+
+        .. math::
+                w = \\frac{1}{|a|^{n-1} N(a; 0, a_{\\rm scale})}
+
         WARNING: this method can be unstable unless you have an extremely
         large number of samples; we do not recommend it when the model has
         more than 2 quadratures (as in the z-parity symmetric models).


### PR DESCRIPTION
Explicitly reweigh result to have a prior that is flat in the amplitude marginals.