### PR TITLE
Fixes to from_imr_result() workflow

### DIFF
--- a/ringdown/data.py
+++ b/ringdown/data.py
@@ -234,7 +234,7 @@ class Series(pd.Series):
         ts.attrs.update(dict(load=info))
         return ts
 
-    _DEF_INTERP_KWS = dict(kind='cubic', fill_value=0, bounds_error=False)
+    _DEF_INTERP_KWS = dict(kind='linear', fill_value=0, bounds_error=False)
 
     def interpolate_to_index(self, new_index, **kwargs):
         """Reinterpolate the :class:`Series` to new index.
@@ -462,7 +462,8 @@ class FrequencySeries(Series):
             f_min = f_min_orig if f_min is None else f_min
             f_max = f_max_orig if f_max is None else f_max
             delta_f = delta_f or self.delta_f
-            n = int((f_max - f_min) / delta_f) + 1
+            # n = int((f_max - f_min) / delta_f) + 1
+            n = len(self.freq)
             freq = np.arange(n)*delta_f + f_min
 
         if min(freq) < f_min_orig or max(freq) > f_max_orig:

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -1933,7 +1933,7 @@ class Fit(object):
             approximant=approximant,
             reference_frequency=reference_frequency,
             psds=psds,
-            **imr_kws
+            **(imr_kws or {})
         )
         imr = fit.imr_result
 

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -1911,6 +1911,7 @@ class Fit(object):
         set_target: bool = True,
         update_model: bool = True,
         duration: float | bool = "auto",
+        imr_kws: dict | None = None,
         data_kws: dict | None = None,
         peak_kws: dict | None = None,
         acf_kws: dict | None = None,
@@ -1932,6 +1933,7 @@ class Fit(object):
             approximant=approximant,
             reference_frequency=reference_frequency,
             psds=psds,
+            **imr_kws
         )
         imr = fit.imr_result
 

--- a/ringdown/imr.py
+++ b/ringdown/imr.py
@@ -446,7 +446,8 @@ class IMRResult(pd.DataFrame):
         """List of detectors in the DataFrame."""
         # try config first
         if "detectors" in self.attrs.get("config", {}):
-            return self.attrs["config"]["detectors"]
+            return [k.replace("'", "") for k in self.attrs["config"]['detectors']]
+            # return self.attrs["config"]['detectors']
         time_keys = [k for k in self.columns if TIME_KEY in k]
         return [k.replace(TIME_KEY, "") for k in time_keys]
 
@@ -803,9 +804,15 @@ class IMRResult(pd.DataFrame):
                     logger.warning("time arrays have inconsistent lengths")
 
         for _, sample in tqdm(df.iterrows(), **tqdm_kws):
-            h = waveforms.get_detector_signals(
-                times=time, ifos=ifos, **sample, **kws
+            if np.array([self.reference_frequency < self.minimum_frequency[ifo] for ifo in ifos]).any():
+                h = waveforms.get_detector_signals(
+                times=time, ifos=ifos, f_low=self.minimum_frequency['waveform'],
+                **sample, **kws
             )
+            else:
+                h = waveforms.get_detector_signals(
+                    times=time, ifos=ifos, **sample, **kws
+                )
             for ifo in ifos:
                 if condition:
                     # look for target time 't0' which can be a dict with
@@ -1600,6 +1607,7 @@ class IMRResult(pd.DataFrame):
             path = os.path.abspath(path)
             r.attrs["path"] = path
             r.attrs.update(attrs)
+            r.set_psds(r.psds)
         else:
             r = cls(path, attrs=attrs, **kws)
         if psds is not None:

--- a/ringdown/imr.py
+++ b/ringdown/imr.py
@@ -1176,7 +1176,7 @@ class IMRResult(pd.DataFrame):
                 logger.info(f"no group provided; using {group}")
             config = pe.config.get(group, {}).get("config", {})
             p = {
-                i: data.PowerSpectrum(p).fill_low_frequencies().gate()
+                i: data.PowerSpectrum(p).fill_low_frequencies().gate().interpolate_to_index()
                 for i, p in pe.psd.get(group, {}).items()
             }
             attrs = (attrs or {}).update({"config": config})
@@ -1212,7 +1212,7 @@ class IMRResult(pd.DataFrame):
                             )
                 if "psds" in f[group]:
                     p = {
-                        i: data.PowerSpectrum(p).fill_low_frequencies().gate()
+                        i: data.PowerSpectrum(p).fill_low_frequencies().gate().interpolate_to_index()
                         for i, p in f[group]["psds"].items()
                     }
                 else:
@@ -1607,7 +1607,6 @@ class IMRResult(pd.DataFrame):
             path = os.path.abspath(path)
             r.attrs["path"] = path
             r.attrs.update(attrs)
-            r.set_psds(r.psds)
         else:
             r = cls(path, attrs=attrs, **kws)
         if psds is not None:

--- a/ringdown/utils/utils.py
+++ b/ringdown/utils/utils.py
@@ -373,8 +373,8 @@ def get_bilby_dict(d):
     """Parse bilby-style data dict string.
     """
     if isinstance(d, str):
-        chars_to_remove = "'{}"
+        chars_to_remove = " '{}"
         translation_table = str.maketrans('', '', chars_to_remove)
         d = {k.translate(translation_table): v.translate(translation_table)
-             for k, v in [i.split(':') for i in d.split(',')]}
+             for k, v in [i.split(':') for i in d.split(',') if ':' in i] }
     return d


### PR DESCRIPTION
I've fixed a few small bugs that arise in the `rd.Fit.from_imr_result()` workflow. 

## **`utils.py`**
Upon reading in the PE configs to store `IMRResult` attributes, some were stored with either extraneous characters or faulty dict patterns. In `utils.py`, `get_bilby_dict()` was at times not removing all space characters and incorrectly splitting the string for a case like `'{ H1:448,L1:448, }'`. I added a `' '` to the characters to remove, and also conditioned the splitting of each new sub-string from `d.split(',')` on there being a `':'` in the sub-string. 

## **`fit.py`**
In the analysis workflow, we sometimes want to indicate a particular set of PE to load from an event's IMR result dataset, i.e. PE with a desired approximant. In `IMRResult.from_pesummary()` there is a `group` keyword argument, but at the abstracted `rd.Fit.from_imr_result()` level, the user cannot specify a group of the IMR `.hdf5` file; rather the group defaults to NRSur7dq4 PE or, if unavailable, the first listed group in the dataset keys. I added an `imr_kws` argument to `from_imr_result()`, which gets propagated to the `IMRResult` constructor and further to `from_pesummary()` in `imr.py`, such that the user can specify the `group` from the top level. 

## **`data.py`**
For PSD interpolation, I noticed that `cubic` interpolation does a poor job for especially spiky PSDs (the interpolation tends to reflect the sharp spikes down to orders of magnitude smaller numbers, producing a PSD that is reminiscent of a round-trip PSD with a too large dynamic range). I've switched to `linear` interpolation instead, see a comparison below:
| `cubic` | `linear` |
| ------ | ------ |
| <img width="1143" height="838" alt="image" src="https://github.com/user-attachments/assets/e8c69cf0-d369-4151-a984-0337a27756aa" /> | <img width="1143" height="838" alt="image" src="https://github.com/user-attachments/assets/45816421-3c8c-45c9-a5fe-cdbf520adeb7" /> |

In some cases, the number of points on the uniformly spaced frequency grid, `n` in `PowerSpectrum.interpolate_to_index()` in `data.py`, was too few; this results in the wrong `delta_t = 1/(2*max(freq))`, or the wrong Nyquist frequency according to the highest frequency bin in the interpolated PSD frequency array. I changed `n` to be equal to the same number of points as in the initial frequency array to ensure the correct Nyquist frequency. 

## **`imr.py`**
If PSDs are added as an `IMRResult` attribute via `IMRResult.set_psds()`, then they are interpolated to a uniform frequency grid by default. However, when an `IMRResult` object is instantiated, the PSDs read in from the `.hdf5` file are not immediately interpolated. I've added default PSD interpolation to the construction of the IMRResult object in `from_pesummary()`. 

Additionally, for some GW events, the `reference-frequency` is set to be lower than the `minimum-frequency` for each ifo; in these cases, the waveform generation for signal templates in the detectors breaks because `f_ref` cannot be less than `f_min`. For these events, I've implemented a fix that passes the starting frequency (`f_start`, or equivalently `waveform` in the `minium-frequency` dict in the PE config) as the `f_low` argument in `IMRResult.get_waveforms()`, rather than the ifo minimum frequency.

Finally, in some cases the `IMRResult.ifos` was storing detectors as `["'H1'", "'L1'"]`, so I modified the `ifos` attribute to remove any spurious quotations.
