### PR TITLE
Upgrade to NumPyro 0.21 and JAX 0.11; require Python 3.12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Bayesian analysis of black hole ringdowns.  The original paper that inspired thi
 
 ## Installation
 
+Requires Python 3.12. Intel Macs are not supported (JAX no longer ships x86_64 macOS wheels).
+
 This package is pip installable:
 
 ```shell
@@ -27,7 +29,7 @@ pip install git+https://github.com/maxisi/ringdown.git
 The default install provides a CPU build of JAX. To run on NVIDIA GPUs, upgrade JAX after installing `ringdown`:
 
 ```shell
-pip install --upgrade "jax[cuda]>=0.4.25,<0.6.1"
+pip install --upgrade "jax[cuda12]==0.11.1"
 ```
 
 See the [JAX documentation](https://jax.readthedocs.io/en/latest/installation.html) for CUDA version details and other accelerators.

--- a/environment.yml
+++ b/environment.yml
@@ -15,8 +15,8 @@ dependencies:
   - tqdm
   - ipywidgets
   - ipykernel
-  - numpyro=0.19.0
-  - jax>=0.4.25,<0.6.1
+  - numpyro=0.21.0
+  - jax=0.11.1
   - parse>=1.20
   - pytables>=3.10,<4
   - scipy>=1.15,<1.16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Astronomy"
 ]
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.12, <3.13"
 dependencies = [
     "numpy==2.2.6",
     "lalsuite==7.26.4",
@@ -25,10 +25,9 @@ dependencies = [
     "pandas~=2.2",
     "qnm==0.4.4",
     "seaborn~=0.13",
-    "numpyro==0.19.0",
-    "jax>=0.4.25,<0.6.1",
+    "numpyro==0.21.0",
+    "jax==0.11.1",
     "parse>=1.20",
-    "jaxlib==0.4.38; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     "tables~=3.10",
     "scipy>=1.15,<1.16",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,8 @@ jupyterlab
 tqdm
 ipywidgets
 ipykernel
-numpyro==0.19.0
-jax>=0.4.25,<0.6.1
+numpyro==0.21.0
+jax==0.11.1
 parse>=1.20
-jaxlib==0.4.38; sys_platform == 'darwin' and platform_machine == 'x86_64'
 tables~=3.10
 scipy>=1.15,<1.16

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -12,7 +12,6 @@ import warnings
 import inspect
 import jax
 import numpyro
-import jaxlib.xla_extension
 import xarray as xr
 import lal
 import logging
@@ -1033,7 +1032,7 @@ class Fit(object):
         rescale_strain: bool = True,
         suppress_warnings: bool = True,
         min_ess: int | None = None,
-        prng: jaxlib.xla_extension.ArrayImpl | int | None = None,
+        prng: jax.Array | int | None = None,
         validation_enabled: bool = False,
         **kwargs,
     ):
@@ -1102,7 +1101,7 @@ class Fit(object):
 
         # log some runtime information
         jax_device_count = jax.device_count()
-        platform = jax.lib.xla_bridge.get_backend().platform.upper()
+        platform = jax.default_backend().upper()
         omp_num_threads = int(os.environ.get("OMP_NUM_THREADS", 1))
         logger.info(
             f"running on {jax_device_count} {platform} using "
@@ -2071,7 +2070,7 @@ class FitSequence(Fit):
         rescale_strain: bool = True,
         suppress_warnings: bool = True,
         min_ess: int | None = None,
-        prng: jaxlib.xla_extension.ArrayImpl | int | None = None,
+        prng: jax.Array | int | None = None,
         validation_enabled: bool = False,
         individual_progress_bars: bool = False,
         recondition: bool = True,
@@ -2134,7 +2133,7 @@ class FitSequence(Fit):
 
         # log some runtime information
         jax_device_count = jax.device_count()
-        platform = jax.lib.xla_bridge.get_backend().platform.upper()
+        platform = jax.default_backend().upper()
         omp_num_threads = int(os.environ.get("OMP_NUM_THREADS", 1))
         logger.info(
             f"running on {jax_device_count} {platform} using "


### PR DESCRIPTION
Drop Intel Mac jaxlib pins and replace removed jax.lib.xla_bridge / jaxlib.xla_extension APIs so sampling works on the new stack.