### PR TITLE
Convert aligned-model amplitudes to generic-model amplitudes

### DIFF
--- a/ringdown/result.py
+++ b/ringdown/result.py
@@ -1116,7 +1116,7 @@ class Result(xr.DataTree):
         """
         if "cosi" in self.posterior:
             cosi = self.posterior.cosi.values
-        elif "cosi" in self.config.get("model", {}):
+        elif self.config.get("model", {}).get("cosi") is not None:
             # inclination was fixed in the fit rather than sampled
             cosi = self.config["model"]["cosi"]
         elif "apx" in self.posterior:

--- a/ringdown/result.py
+++ b/ringdown/result.py
@@ -1089,6 +1089,25 @@ class Result(xr.DataTree):
         new_result = self.copy()
         new_result["posterior"] = samples.isel(sample=idxs)
         return new_result
+    
+    def get_generic_amplitude(self):
+
+        if 'cosi' not in self.posterior.keys(): 
+            raise KeyError('Must be result of fit using aligned model')
+        else:
+            A_j = [] # collect the computed generic amplitudes per mode, to be stacked at the end
+                
+            for mode in self.modes:
+                ### C is the "amplitude" returned by the aligned model, with angular factors still factored out
+                C = self.posterior.a.sel(mode=bytes('1,-2,{},{},{}'.format(mode.l, mode.m, mode.n), 'utf-8')).values
+                cosi = self.posterior.cosi.values
+                swsh = utils.swsh.construct_sYlm(-2, mode.l, mode.m)
+                ylm_p = swsh(cosi)
+                ylm_m = swsh(-cosi)
+                A = C * (np.abs(ylm_p) + np.abs(ylm_m))
+                A_j.append(A)
+            
+            return np.stack(A_j, axis=-1)
 
     def imr_consistency(
         self,

--- a/ringdown/result.py
+++ b/ringdown/result.py
@@ -14,6 +14,7 @@ from .imr import IMRResult
 from .target import Target, TargetCollection
 from . import utils
 from .utils import stats
+from .utils.swsh import construct_sYlm
 from .config import WHITENED_LOGLIKE_KEY
 import pandas as pd
 import json
@@ -56,6 +57,7 @@ def _stock_matplotlib_axes():
     finally:
         if hijacked:
             register_projection(prev)
+
 
 _DATAFRAME_PARAMETERS = [
     "m",
@@ -1089,25 +1091,55 @@ class Result(xr.DataTree):
         new_result = self.copy()
         new_result["posterior"] = samples.isel(sample=idxs)
         return new_result
-    
-    def get_generic_amplitude(self):
 
-        if 'cosi' not in self.posterior.keys(): 
-            raise KeyError('Must be result of fit using aligned model')
+    def get_generic_amplitude(self) -> xr.DataArray:
+        """Compute the generic-model amplitudes implied by an aligned-model
+        fit.
+
+        In the aligned model, the angular factors are factored out of the
+        mode amplitudes, so the sampled amplitude ``a`` is not directly
+        comparable to the generic-model amplitude, which absorbs them. The
+        equivalent generic-model amplitude is
+
+        .. math::
+            A_{\\rm generic} = A_{\\rm aligned} \\left(
+            \\left| {}_{-2}Y_{\\ell m}(\\iota) \\right| +
+            \\left| {}_{-2}Y_{\\ell m}(\\pi - \\iota) \\right| \\right)
+
+        which relies on the equatorial symmetry enforced by the aligned
+        model.
+
+        Returns
+        -------
+        a : xr.DataArray
+            generic-model amplitudes with dimensions (chain, draw, mode).
+        """
+        if "cosi" in self.posterior:
+            cosi = self.posterior.cosi.values
+        elif "cosi" in self.config.get("model", {}):
+            # inclination was fixed in the fit rather than sampled
+            cosi = self.config["model"]["cosi"]
+        elif "apx" in self.posterior:
+            raise ValueError(
+                "result comes from a generic-polarization fit, so its "
+                "amplitudes are already generic"
+            )
         else:
-            A_j = [] # collect the computed generic amplitudes per mode, to be stacked at the end
-                
-            for mode in self.modes:
-                ### C is the "amplitude" returned by the aligned model, with angular factors still factored out
-                C = self.posterior.a.sel(mode=bytes('1,-2,{},{},{}'.format(mode.l, mode.m, mode.n), 'utf-8')).values
-                cosi = self.posterior.cosi.values
-                swsh = utils.swsh.construct_sYlm(-2, mode.l, mode.m)
-                ylm_p = swsh(cosi)
-                ylm_m = swsh(-cosi)
-                A = C * (np.abs(ylm_p) + np.abs(ylm_m))
-                A_j.append(A)
-            
-            return np.stack(A_j, axis=-1)
+            raise KeyError(
+                "no inclination information found: 'cosi' is neither in "
+                "the posterior nor fixed in the configuration; an "
+                "aligned-model result is required"
+            )
+        amplitudes = []
+        for mode in self.modes:
+            a = self.posterior.a.sel(mode=mode.get_coordinate())
+            swsh = construct_sYlm(-2, mode.l, mode.m)
+            ylm_p = np.abs(np.asarray(swsh(cosi)))
+            ylm_m = np.abs(np.asarray(swsh(-cosi)))
+            amplitudes.append(a * (ylm_p + ylm_m))
+        return xr.concat(amplitudes, dim="mode").transpose(
+            "chain", "draw", "mode"
+        )
 
     def imr_consistency(
         self,

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -121,6 +121,7 @@ def test_get_generic_amplitude_requires_aligned_fit():
     with pytest.raises(KeyError, match="aligned-model"):
         result.get_generic_amplitude()
     result.posterior["apx"] = result.posterior.a
+    result.attrs["config"] = json.dumps({"model": {"cosi": None}})
     with pytest.raises(ValueError, match="generic"):
         result.get_generic_amplitude()
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,10 +1,14 @@
 import json
 from html import escape
 
+import numpy as np
+import pytest
 import xarray as xr
 from arviz_base import dict_to_dataset
 
+from ringdown.model import Aellip_from_quadratures
 from ringdown.result import Result
+from ringdown.utils.swsh import construct_sYlm
 
 
 def test_strain_scale_length_one_constant_data():
@@ -32,6 +36,93 @@ def test_repr_html_config_collapsible():
     assert "a_max: 1e-20" in html
     # other attributes untouched
     assert "<dd>plain value</dd>" in html
+
+
+def _aligned_posterior(modes, nchain=2, ndraw=10, cosi=True, seed=1234):
+    # synthetic aligned-model posterior with amplitudes for the given modes
+    rng = np.random.default_rng(seed)
+    data = {
+        "a": (
+            ("chain", "draw", "mode"),
+            rng.uniform(0.1, 5.0, (nchain, ndraw, len(modes))),
+        ),
+    }
+    if cosi:
+        data["cosi"] = (
+            ("chain", "draw"),
+            rng.uniform(-1, 1, (nchain, ndraw)),
+        )
+    posterior = xr.Dataset(
+        data,
+        coords={
+            "chain": np.arange(nchain),
+            "draw": np.arange(ndraw),
+            "mode": np.array(modes),
+        },
+    )
+    return Result(xr.DataTree.from_dict({"posterior": posterior}))
+
+
+def test_generic_amplitude_matches_quadrature_definition():
+    # the aligned-to-generic amplitude conversion must reproduce the
+    # generic model's own amplitude definition when applied to the
+    # aligned-model quadratures
+    rng = np.random.default_rng(42)
+    for ell, m in [(2, 2), (2, 1), (3, 3), (3, 2), (4, 4)]:
+        cosi = rng.uniform(-1, 1)
+        c = rng.uniform(0.1, 5.0)
+        phi = rng.uniform(0, 2 * np.pi)
+        swsh = construct_sYlm(-2, ell, m)
+        ylm_p = np.asarray(swsh(cosi)).ravel()[0]
+        ylm_m = np.asarray(swsh(-cosi)).ravel()[0]
+        yp, yc = ylm_p + ylm_m, ylm_p - ylm_m
+        apx, apy = c * yp * np.cos(phi), c * yp * np.sin(phi)
+        acx, acy = -c * yc * np.sin(phi), c * yc * np.cos(phi)
+        a_generic, _ = Aellip_from_quadratures(apx, apy, acx, acy)
+        a_converted = c * (np.abs(ylm_p) + np.abs(ylm_m))
+        assert np.isclose(float(a_generic), a_converted)
+
+
+def test_get_generic_amplitude():
+    # includes a retrograde mode, which must be indexed correctly
+    modes = [b"1,-2,2,2,0", b"1,-2,3,3,0", b"-1,-2,2,2,0"]
+    result = _aligned_posterior(modes)
+    a = result.get_generic_amplitude()
+    assert a.dims == ("chain", "draw", "mode")
+    assert list(a.mode.values) == modes
+    cosi = result.posterior.cosi.values
+    for mode in modes:
+        _, _, ell, m, _ = map(int, mode.decode().split(","))
+        swsh = construct_sYlm(-2, ell, m)
+        expected = result.posterior.a.sel(mode=mode).values * (
+            np.abs(np.asarray(swsh(cosi)))
+            + np.abs(np.asarray(swsh(-cosi)))
+        )
+        assert np.allclose(a.sel(mode=mode).values, expected)
+
+
+def test_get_generic_amplitude_fixed_cosi():
+    # a fit with fixed inclination stores no cosi samples; the value must
+    # be picked up from the configuration instead
+    modes = [b"1,-2,2,2,0"]
+    result = _aligned_posterior(modes, cosi=False)
+    result.attrs["config"] = json.dumps({"model": {"cosi": "0.3"}})
+    a = result.get_generic_amplitude()
+    swsh = construct_sYlm(-2, 2, 2)
+    expected = result.posterior.a.sel(mode=modes[0]).values * (
+        np.abs(np.asarray(swsh(0.3))) + np.abs(np.asarray(swsh(-0.3)))
+    )
+    assert np.allclose(a.sel(mode=modes[0]).values, expected)
+
+
+def test_get_generic_amplitude_requires_aligned_fit():
+    modes = [b"1,-2,2,2,0"]
+    result = _aligned_posterior(modes, cosi=False)
+    with pytest.raises(KeyError, match="aligned-model"):
+        result.get_generic_amplitude()
+    result.posterior["apx"] = result.posterior.a
+    with pytest.raises(ValueError, match="generic"):
+        result.get_generic_amplitude()
 
 
 def test_repr_html_without_config():


### PR DESCRIPTION
Adds `Result.get_generic_amplitude()`, which converts the amplitude parameter of the aligned polarization model into the amplitude convention of the generic model.

The method and the underlying conversion,

$$A_\mathrm{generic} = A_\mathrm{aligned}\left(\left|{}_{-2}Y_{\ell m}(\iota)\right| + \left|{}_{-2}Y_{\ell m}(\pi-\iota)\right|\right),$$

were written by @nkhusid and originally proposed in #98; this PR carries that work over (preserving commit authorship) so it can merge independently of the polarization-angle parameterization also present on that branch. The conversion was verified analytically and numerically against the generic model's own amplitude definition (`Aellip_from_quadratures`).

Fixes applied on top of the original commit:

- index modes via `ModeIndex.get_coordinate()` instead of a hardcoded prograde bytestring, so retrograde modes work;
- when the fit fixed the inclination (no `cosi` samples in the posterior), fall back to the value stored in the fit configuration, and raise informative errors otherwise (generic-model fit vs. missing inclination);
- return a labeled `DataArray` with `(chain, draw, mode)` dimensions instead of a bare numpy array;
- add a docstring stating the conversion and its aligned-model (equatorial symmetry) assumption;
- add regression tests, including the identity between the converted amplitude and `Aellip_from_quadratures` applied to the aligned-model quadratures.

Closes #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)