### PR TITLE
Fix sign and trig function in rd_design_matrix docstring matrix

### DIFF
--- a/ringdown/model.py
+++ b/ringdown/model.py
@@ -172,8 +172,8 @@ def rd_design_matrix(
         M = \\begin{pmatrix}
             F_+ Y_{\\ell m}^+ \\cos\\omega t + F_\\times Y_{\\ell m}^\\times
             \\sin\\omega t \\\\
-            F_+ Y_{\\ell m}^+ \\sin\\omega t + F_\\times Y_{\\ell m}^\\times
-            \\sin\\omega t \\\\
+            F_+ Y_{\\ell m}^+ \\sin\\omega t - F_\\times Y_{\\ell m}^\\times
+            \\cos\\omega t \\\\
         \\end{pmatrix}
 
     This function effects that summation to return a design matrix


### PR DESCRIPTION
The typeset matrix M gave its second row as $F_+ Y^+ \sin(wt) + F_x Y^x \sin(wt)$, but the code computes $F_+ Y^+ \sin(wt) - F_x Y^x \cos(wt)$. The prose derivation just above expands to what the code does, so only the LaTeX matrix was wrong.