### PR TITLE
Default to vectorized chains when devices are fewer than chains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,13 @@ Notable user-facing changes to `ringdown`. For a full history, see the
 
 ## Unreleased
 
+- On accelerators (GPU/TPU), `chain_method` now defaults to `'vectorized'`
+  whenever there are fewer devices than chains, rather than letting NumPyro
+  fall back to drawing chains sequentially. Pass `chain_method` explicitly
+  (in `sampler_kws` or the `[run]` config section) to override.
+- Fixed the CLI `--device-count` clamp: requesting more CPU devices than
+  available cores logged a warning but then skipped
+  `numpyro.set_host_device_count` entirely, leaving JAX on a single device.
 - Migrated to arviz 1.x (#154): `Result` now subclasses `xarray.DataTree`
   instead of wrapping `arviz.InferenceData`. Most idioms carry over; notable
   changes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Notable user-facing changes to `ringdown`. For a full history, see the
 - On accelerators (GPU/TPU), `chain_method` now defaults to `'vectorized'`
   whenever there are fewer devices than chains, rather than letting NumPyro
   fall back to drawing chains sequentially. Pass `chain_method` explicitly
-  (in `sampler_kws` or the `[run]` config section) to override.
+  (directly, via `sampler`, or the `[run]` config section) to override.
 - Fixed the CLI `--device-count` clamp: requesting more CPU devices than
   available cores logged a warning but then skipped
   `numpyro.set_host_device_count` entirely, leaving JAX on a single device.

--- a/ringdown/cli/ringdown_fit.py
+++ b/ringdown/cli/ringdown_fit.py
@@ -118,8 +118,7 @@ def main(args=None, defout=DEFOUT):
                 f"({cpu_count})."
             )
             args.device_count = cpu_count
-        else:
-            numpyro.set_host_device_count(args.device_count)
+        numpyro.set_host_device_count(args.device_count)
 
     if os.path.exists(out):
         if args.force:
@@ -141,9 +140,10 @@ def main(args=None, defout=DEFOUT):
 
     ext = os.path.splitext(out)[-1]
     if ext.lower() != ".nc":
-        logging.warning(f"unsupported output format {ext!r}: only netCDF (.nc) output is supported")
+        logging.warning(
+            f"unsupported output format {ext!r}: only netCDF (.nc) output is supported")
         out = out + ".nc"
-    
+
     result.to_netcdf(out)
 
     print(f"Saved ringdown fit: {out}")

--- a/ringdown/cli/ringdown_scan.py
+++ b/ringdown/cli/ringdown_scan.py
@@ -127,8 +127,7 @@ def main(args=None):
                 f"({cpu_count})."
             )
             args.device_count = cpu_count
-        else:
-            numpyro.set_host_device_count(args.device_count)
+        numpyro.set_host_device_count(args.device_count)
 
     ##########################################################################
     # RUN FIT

--- a/ringdown/fit.py
+++ b/ringdown/fit.py
@@ -67,6 +67,22 @@ def get_sampling_kwargs(**kwargs):
     sampler_kws = kws.pop("sampler", {})
     sampler_kws.update({k: v for k, v in kws.items() if k in SAMPLER_ARGS})
 
+    # NumPyro's default `chain_method='parallel'` silently degrades to
+    # sequential sampling whenever there are fewer devices than chains, which
+    # is the norm on GPU (where the CLI defaults to a single device); on
+    # accelerators a single device can run all chains at once instead
+    if "chain_method" not in sampler_kws:
+        num_chains = sampler_kws.get("num_chains", 1)
+        # NB: NumPyro compares against `local_device_count`, so match it
+        device_count = jax.local_device_count()
+        backend = jax.default_backend()
+        if num_chains > device_count and backend != "cpu":
+            sampler_kws["chain_method"] = "vectorized"
+            logger.info(
+                f"defaulting to chain_method='vectorized' for {num_chains} "
+                f"chains on {device_count} {backend.upper()} device(s)"
+            )
+
     # assume leftover arguments will be passed to run method
     run_kws = {
         k: v

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,0 +1,52 @@
+"""Tests for sampler keyword handling in :mod:`ringdown.fit`."""
+
+import pytest
+
+from ringdown import fit as rdfit
+
+
+def _patch_device(monkeypatch, backend, device_count):
+    monkeypatch.setattr(rdfit.jax, "default_backend", lambda: backend)
+    monkeypatch.setattr(
+        rdfit.jax, "local_device_count", lambda: device_count
+    )
+
+
+@pytest.mark.parametrize(
+    "backend, device_count, expected",
+    [
+        # fewer accelerators than chains: NumPyro's 'parallel' would fall
+        # back to sequential sampling, so vectorize instead
+        ("gpu", 1, "vectorized"),
+        ("gpu", 2, "vectorized"),
+        # enough accelerators for one chain each: leave 'parallel' alone
+        ("gpu", 4, None),
+        ("gpu", 8, None),
+        # CPU keeps NumPyro's default regardless of device count
+        ("cpu", 1, None),
+        ("cpu", 4, None),
+    ],
+)
+def test_chain_method_default(monkeypatch, backend, device_count, expected):
+    _patch_device(monkeypatch, backend, device_count)
+    _, sampler_kws, _ = rdfit.get_sampling_kwargs(num_chains=4)
+    assert sampler_kws.get("chain_method") == expected
+
+
+def test_chain_method_not_set_for_single_chain(monkeypatch):
+    _patch_device(monkeypatch, "gpu", 1)
+    _, sampler_kws, _ = rdfit.get_sampling_kwargs(num_chains=1)
+    assert "chain_method" not in sampler_kws
+
+
+@pytest.mark.parametrize(
+    "kws",
+    [
+        {"chain_method": "sequential"},
+        {"sampler": {"chain_method": "sequential"}},
+    ],
+)
+def test_explicit_chain_method_is_respected(monkeypatch, kws):
+    _patch_device(monkeypatch, "gpu", 1)
+    _, sampler_kws, _ = rdfit.get_sampling_kwargs(num_chains=4, **kws)
+    assert sampler_kws["chain_method"] == "sequential"

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,8 +1,11 @@
 """Tests for sampler keyword handling in :mod:`ringdown.fit`."""
 
+from configparser import ConfigParser
+
 import pytest
 
 from ringdown import fit as rdfit
+from ringdown.cli import ringdown_fit
 
 
 def _patch_device(monkeypatch, backend, device_count):
@@ -50,3 +53,33 @@ def test_explicit_chain_method_is_respected(monkeypatch, kws):
     _patch_device(monkeypatch, "gpu", 1)
     _, sampler_kws, _ = rdfit.get_sampling_kwargs(num_chains=4, **kws)
     assert sampler_kws["chain_method"] == "sequential"
+
+
+def test_cpu_device_count_is_clamped(monkeypatch, tmp_path):
+    device_counts = []
+
+    class Fit:
+        result = type("Result", (), {"to_netcdf": lambda *_: None})()
+        prior = result
+
+        def run(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(ringdown_fit.os, "cpu_count", lambda: 2)
+    monkeypatch.setattr(
+        ringdown_fit.rd.utils, "load_config", lambda _: ConfigParser()
+    )
+    monkeypatch.setattr(
+        ringdown_fit.rd.Fit, "from_config", lambda _: Fit()
+    )
+    monkeypatch.setattr(ringdown_fit.numpyro, "set_platform", lambda _: None)
+    monkeypatch.setattr(
+        ringdown_fit.numpyro, "set_host_device_count", device_counts.append
+    )
+    monkeypatch.setattr(ringdown_fit.jax_config, "update", lambda *_: None)
+
+    ringdown_fit.main([
+        "--device-count", "4", "--output", str(tmp_path / "fit.nc"), "input.ini"
+    ])
+
+    assert device_counts == [2]

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,32 @@
+"""Tests for the scan command-line interface."""
+
+from configparser import ConfigParser
+
+from ringdown.cli import ringdown_scan
+
+
+def test_cpu_device_count_is_clamped(monkeypatch, tmp_path):
+    device_counts = []
+
+    class FitSequence:
+        targets = []
+
+    config_path = tmp_path / "input.ini"
+    config_path.touch()
+
+    monkeypatch.setattr(ringdown_scan.os, "cpu_count", lambda: 2)
+    monkeypatch.setattr(
+        ringdown_scan.rd.utils, "load_config", lambda _: ConfigParser()
+    )
+    monkeypatch.setattr(
+        ringdown_scan.rd.FitSequence, "from_config", lambda _: FitSequence()
+    )
+    monkeypatch.setattr(ringdown_scan.numpyro, "set_platform", lambda _: None)
+    monkeypatch.setattr(
+        ringdown_scan.numpyro, "set_host_device_count", device_counts.append
+    )
+    monkeypatch.setattr(ringdown_scan.jax_config, "update", lambda *_: None)
+
+    ringdown_scan.main(["--device-count", "4", str(config_path)])
+
+    assert device_counts == [2]


### PR DESCRIPTION
NumPyro's default `chain_method='parallel'` silently degrades to sequential sampling whenever `local_device_count() < num_chains` (numpyro/infer/mcmc.py:359). Since the CLI defaults GPU `device_count` to 1 while `DEF_RUN_KWS` asks for 4 chains, every GPU run has been drawing its chains one after another on a card that is idle most of the time.

Default `chain_method` to 'vectorized' in `get_sampling_kwargs` when running on an accelerator with fewer devices than chains. That is the single choke point for sampler kwargs, so this covers `Fit.run`, `FitSequence.run`, and both CLI entry points at once. An explicit `chain_method` -- passed directly, via `sampler_kws`, or in the `[run]` config section -- still wins. CPU is deliberately left alone, since its default device count already matches the default chain count.

Measured on an A6000 (see GPU_BENCHMARKS.md 4.2), 4 vectorized chains beat 4 nominally-parallel ones, and throughput scales up to 14-23x for wide ensembles.

Also fix the CLI `--device-count` clamp: the CPU over-request branch set `args.device_count = cpu_count` but sat opposite the `else` that called `numpyro.set_host_device_count`, so the clamped value was never applied and JAX stayed on one device.