### PR TITLE
Let the @claude workflow push, and gate it on a trusted author

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,23 +12,45 @@ on:
 
 jobs:
   claude:
+    # Two conditions, both required: the comment mentions @claude, AND its
+    # author is trusted.  The author check exists because this job holds
+    # `contents: write` (see below) on a PUBLIC repo, where `issue_comment`
+    # fires for any GitHub user.  Without it, anyone who can type a comment
+    # could make the bot push to this repository.  OWNER/MEMBER/COLLABORATOR
+    # are exactly the associations that already imply write access.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      # `contents: write` lets Claude push the fixes it is asked to make.  With
+      # `contents: read` it would do the work and then die on
+      # "Permission to <repo> denied to github-actions[bot] ... 403", stranding
+      # the commit in the runner (this is what happened on PR #165).
+      # Mirrors the permissions claude-docs-sync.yml already uses.
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 1
+          # Full history, not a depth-1 shallow clone: pushing a new commit
+          # from a shallow checkout is unreliable, and Claude is now expected
+          # to push.  claude-docs-sync.yml uses 0 for the same reason.
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Why

On #165 the `@claude` bot was asked to fix review findings. It made the changes, committed them in the runner, then failed:

```
remote: Permission to maxisi/ringdown.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/maxisi/ringdown.git/': The requested URL returned error: 403
```

The job holds `contents: read`, so the commit could never leave the runner and the work was lost when the runner was torn down. (Those fixes have since been recreated by hand and pushed to #165; this PR stops it happening again.)

## What changed

- `contents: write`, `pull-requests: write`, `issues: write` on the `claude` job, matching what `claude-docs-sync.yml` already uses.
- `fetch-depth: 0` instead of `1`, since pushing from a shallow checkout is unreliable and the job is now expected to push.
- The trigger is gated on `author_association` being `OWNER`, `MEMBER` or `COLLABORATOR`.

## On the author gate

This repo is public, so `issue_comment` fires for any GitHub user. Granting `contents: write` without a gate would let anyone who can type a comment make the bot push here. `OWNER`/`MEMBER`/`COLLABORATOR` are exactly the associations that already imply write access, so the gate takes nothing away from anyone who could push anyway.

Checked against the real trigger comments on #165: both are `OWNER`, so they would still fire. `claude[bot]`'s own comments carry `NONE`, so this also stops the bot retriggering itself.

`claude-code-review.yml` is deliberately left read-only. It only posts reviews and has no reason to push.

## Caveat

Workflow changes for `issue_comment` take effect from the **default branch**, so the bot cannot push anywhere until this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
